### PR TITLE
feat: add multiselect support for enum parameters

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -152,6 +152,7 @@ func runRender(cmd *cobra.Command, args []string) error {
 	// Step 2: Build dynamic form based on template parameters
 	params := make(map[string]interface{})
 	paramValues := make(map[string]*string)
+	multiSelectValues := make(map[string]*[]string)
 
 	// Create form fields for each parameter
 	var formGroups []*huh.Group
@@ -159,22 +160,39 @@ func runRender(cmd *cobra.Command, args []string) error {
 	var visibleCount int
 
 	for _, p := range tmpl.Spec.Parameters {
-		// Create a string pointer to hold the value (including hidden params)
-		defaultVal := ""
-		if p.Default != nil {
-			defaultVal = fmt.Sprintf("%v", p.Default)
-		}
-		paramValues[p.Name] = &defaultVal
-
 		// Skip hidden parameters - they use their default value
 		if p.Hidden {
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
 			continue
 		}
 
-		visibleCount++
-		field := createField(p, paramValues[p.Name])
-		if field != nil {
-			currentFields = append(currentFields, field)
+		// Handle multiselect parameters
+		if p.Multiselect && len(p.Enum) > 0 {
+			defaults := defaultsToStringSlice(p.Default)
+			multiSelectValues[p.Name] = &defaults
+
+			visibleCount++
+			field := createMultiSelectField(p, multiSelectValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
+		} else {
+			// Create a string pointer to hold the value (including hidden params)
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
+
+			visibleCount++
+			field := createField(p, paramValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
 		}
 
 		// Group fields (max 5 per group for better UX)
@@ -201,7 +219,19 @@ func runRender(cmd *cobra.Command, args []string) error {
 	// Resolve random selections and pass all values as strings
 	rand.Seed(time.Now().UnixNano())
 	for _, p := range tmpl.Spec.Parameters {
-		strVal := *paramValues[p.Name]
+		// Handle multiselect values
+		if p.Multiselect && len(p.Enum) > 0 {
+			if vals, ok := multiSelectValues[p.Name]; ok && len(*vals) > 0 {
+				params[p.Name] = *vals
+			}
+			continue
+		}
+
+		valPtr, ok := paramValues[p.Name]
+		if !ok {
+			continue
+		}
+		strVal := *valPtr
 		if strVal == "" {
 			continue
 		}
@@ -249,10 +279,15 @@ func runRender(cmd *cobra.Command, args []string) error {
 		allParams[k] = v
 	}
 
-	// Convert all values to strings (KCL expects string types)
+	// Convert scalar values to strings; preserve slices for KCL list rendering
 	stringParams := make(map[string]interface{})
 	for k, v := range allParams {
-		stringParams[k] = fmt.Sprintf("%v", v)
+		switch v.(type) {
+		case []string, []interface{}:
+			stringParams[k] = v
+		default:
+			stringParams[k] = fmt.Sprintf("%v", v)
+		}
 	}
 
 	result := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
@@ -287,6 +322,46 @@ func runRender(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// defaultsToStringSlice converts a parameter's Default value to a []string.
+func defaultsToStringSlice(def interface{}) []string {
+	if def == nil {
+		return nil
+	}
+	switch v := def.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+// createMultiSelectField creates a multi-select huh field for parameters with multiselect: true.
+func createMultiSelectField(p claimtemplate.Parameter, value *[]string) huh.Field {
+	title := p.Title
+	if p.Required {
+		title += " *"
+	}
+
+	description := p.Description
+
+	var options []huh.Option[string]
+	for _, e := range p.Enum {
+		options = append(options, huh.NewOption(e, e))
+	}
+
+	return huh.NewMultiSelect[string]().
+		Title(title).
+		Description(description).
+		Options(options...).
+		Value(value)
 }
 
 // createField creates the appropriate huh field based on parameter type

--- a/internal/app/renderer.go
+++ b/internal/app/renderer.go
@@ -16,7 +16,20 @@ func BuildParameterValues(t *claimtemplate.ClaimTemplate) map[string]interface{}
 	for _, p := range t.Spec.Parameters {
 		// Use default value if available, otherwise use a reasonable default
 		if p.Default != nil {
-			params[p.Name] = p.Default
+			// For multiselect parameters, convert []interface{} defaults to []string
+			if p.Multiselect {
+				if items, ok := p.Default.([]interface{}); ok {
+					strs := make([]string, 0, len(items))
+					for _, item := range items {
+						strs = append(strs, fmt.Sprintf("%v", item))
+					}
+					params[p.Name] = strs
+				} else {
+					params[p.Name] = p.Default
+				}
+			} else {
+				params[p.Name] = p.Default
+			}
 		} else {
 			// Provide reasonable defaults based on type
 			switch p.Type {

--- a/internal/claimtemplate/claimtemplate.go
+++ b/internal/claimtemplate/claimtemplate.go
@@ -46,6 +46,10 @@ type Parameter struct {
 	// Only applies to parameters with enum values
 	AllowRandom bool `yaml:"allowRandom,omitempty" json:"allowRandom,omitempty"`
 
+	// Multiselect allows selecting multiple values from enum options
+	// Only applies to parameters with enum values
+	Multiselect bool `yaml:"multiselect,omitempty" json:"multiselect,omitempty"`
+
 	// Validation
 	Pattern   string `yaml:"pattern,omitempty" json:"pattern,omitempty"`
 	MinLength *int   `yaml:"minLength,omitempty" json:"minLength,omitempty"`

--- a/internal/claimtemplate/loader_test.go
+++ b/internal/claimtemplate/loader_test.go
@@ -23,3 +23,30 @@ func TestLoadClaimTemplate(t *testing.T) {
 	require.Equal(t, "string", param.Type)
 	require.Contains(t, param.Enum, "simple")
 }
+
+func TestLoadClaimTemplate_Multiselect(t *testing.T) {
+	tmpl, err := claimtemplate.LoadClaimTemplate("testdata/multiselect.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t, "ClaimTemplate", tmpl.Kind)
+	require.Equal(t, "multiselect-test", tmpl.Metadata.Name)
+	require.Len(t, tmpl.Spec.Parameters, 2)
+
+	// First param should have multiselect: true
+	playbooks := tmpl.Spec.Parameters[0]
+	require.Equal(t, "playbooks", playbooks.Name)
+	require.True(t, playbooks.Multiselect)
+	require.Equal(t, "array", playbooks.Type)
+	require.Equal(t, []string{"baseos", "deploy-docker", "configure-network"}, playbooks.Enum)
+
+	// Default should be parsed as a list
+	defaults, ok := playbooks.Default.([]interface{})
+	require.True(t, ok, "default should be []interface{}")
+	require.Len(t, defaults, 1)
+	require.Equal(t, "baseos", defaults[0])
+
+	// Second param should not have multiselect
+	name := tmpl.Spec.Parameters[1]
+	require.Equal(t, "name", name.Name)
+	require.False(t, name.Multiselect)
+}

--- a/internal/claimtemplate/testdata/multiselect.yaml
+++ b/internal/claimtemplate/testdata/multiselect.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: ClaimTemplate
+metadata:
+  name: multiselect-test
+  title: Multiselect Test Template
+  description: Template for testing multiselect parameter support
+spec:
+  type: test
+  source: oci://ghcr.io/stuttgart-things/test
+  tag: 0.1.0
+  parameters:
+    - name: playbooks
+      title: Playbooks
+      description: Select one or more playbooks to run
+      type: array
+      multiselect: true
+      enum:
+        - baseos
+        - deploy-docker
+        - configure-network
+      default:
+        - baseos
+
+    - name: name
+      title: Resource Name
+      type: string
+      default: test-resource

--- a/internal/render/kcl.go
+++ b/internal/render/kcl.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	kcl "kcl-lang.io/kcl-go"
 )
@@ -84,7 +85,7 @@ func RenderKCLFromOCI(
 	// Add parameters as -D flags
 	for key, value := range allAnswers {
 		fmt.Printf("%s=%v\n", key, value)
-		args = append(args, "-D", fmt.Sprintf("%s=%v", key, value))
+		args = append(args, "-D", formatKCLFlag(key, value))
 	}
 
 	// Execute kcl CLI command
@@ -132,9 +133,16 @@ func convertToOptionStrings(answers map[string]interface{}) []string {
 		// Convert the value to string
 		var strValue string
 		switch v := value.(type) {
+		case []string:
+			strValue = formatKCLList(v)
+		case []interface{}:
+			items := make([]string, 0, len(v))
+			for _, item := range v {
+				items = append(items, fmt.Sprintf("%v", item))
+			}
+			strValue = formatKCLList(items)
 		case string:
-			strValue = v
-			strValue = "'" + strValue + "'"
+			strValue = "'" + v + "'"
 		}
 
 		// Create the "key=value" string and add to slice
@@ -142,6 +150,31 @@ func convertToOptionStrings(answers map[string]interface{}) []string {
 	}
 
 	return options
+}
+
+// formatKCLFlag formats a key-value pair as a KCL -D flag string.
+func formatKCLFlag(key string, value interface{}) string {
+	switch v := value.(type) {
+	case []string:
+		return fmt.Sprintf("%s=%s", key, formatKCLList(v))
+	case []interface{}:
+		items := make([]string, 0, len(v))
+		for _, item := range v {
+			items = append(items, fmt.Sprintf("%v", item))
+		}
+		return fmt.Sprintf("%s=%s", key, formatKCLList(items))
+	default:
+		return fmt.Sprintf("%s=%v", key, value)
+	}
+}
+
+// formatKCLList formats a string slice as a KCL list literal, e.g. ["a","b"].
+func formatKCLList(items []string) string {
+	quoted := make([]string, 0, len(items))
+	for _, item := range items {
+		quoted = append(quoted, `"`+item+`"`)
+	}
+	return "[" + strings.Join(quoted, ",") + "]"
 }
 
 // replaceTripleQuotes replaces ”'value”' with 'value' in a string

--- a/tests/cli-api/main.go
+++ b/tests/cli-api/main.go
@@ -50,6 +50,7 @@ type Parameter struct {
 	Pattern     string      `json:"pattern,omitempty"`
 	Hidden      bool        `json:"hidden,omitempty"`
 	AllowRandom bool        `json:"allowRandom,omitempty"`
+	Multiselect bool        `json:"multiselect,omitempty"`
 }
 
 type ClaimTemplateList struct {
@@ -145,27 +146,44 @@ func main() {
 	// Step 2: Build dynamic form based on template parameters
 	params := make(map[string]interface{})
 	paramValues := make(map[string]*string)
+	multiSelectValues := make(map[string]*[]string)
 
 	// Create form fields for each parameter
 	var formGroups []*huh.Group
 	var currentFields []huh.Field
 
 	for _, p := range tmpl.Spec.Parameters {
-		// Create a string pointer to hold the value (including hidden params)
-		defaultVal := ""
-		if p.Default != nil {
-			defaultVal = fmt.Sprintf("%v", p.Default)
-		}
-		paramValues[p.Name] = &defaultVal
-
 		// Skip hidden parameters - they use their default value
 		if p.Hidden {
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
 			continue
 		}
 
-		field := createField(p, paramValues[p.Name])
-		if field != nil {
-			currentFields = append(currentFields, field)
+		// Handle multiselect parameters
+		if p.Multiselect && len(p.Enum) > 0 {
+			defaults := defaultsToStringSlice(p.Default)
+			multiSelectValues[p.Name] = &defaults
+
+			field := createMultiSelectField(p, multiSelectValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
+		} else {
+			// Create a string pointer to hold the value (including hidden params)
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
+
+			field := createField(p, paramValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
 		}
 
 		// Group fields (max 5 per group for better UX)
@@ -192,7 +210,19 @@ func main() {
 	// Resolve random selections and collect non-empty values
 	rand.Seed(time.Now().UnixNano())
 	for _, p := range tmpl.Spec.Parameters {
-		strVal := *paramValues[p.Name]
+		// Handle multiselect values
+		if p.Multiselect && len(p.Enum) > 0 {
+			if vals, ok := multiSelectValues[p.Name]; ok && len(*vals) > 0 {
+				params[p.Name] = *vals
+			}
+			continue
+		}
+
+		valPtr, ok := paramValues[p.Name]
+		if !ok {
+			continue
+		}
+		strVal := *valPtr
 		if strVal == "" {
 			continue
 		}
@@ -314,6 +344,46 @@ func renderTemplate(client *http.Client, apiURL, templateName string, params map
 	}
 
 	return orderResp.Rendered, nil
+}
+
+// defaultsToStringSlice converts a parameter's Default value to a []string.
+func defaultsToStringSlice(def interface{}) []string {
+	if def == nil {
+		return nil
+	}
+	switch v := def.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+// createMultiSelectField creates a multi-select huh field for parameters with multiselect: true.
+func createMultiSelectField(p Parameter, value *[]string) huh.Field {
+	title := p.Title
+	if p.Required {
+		title += " *"
+	}
+
+	description := p.Description
+
+	var options []huh.Option[string]
+	for _, e := range p.Enum {
+		options = append(options, huh.NewOption(e, e))
+	}
+
+	return huh.NewMultiSelect[string]().
+		Title(title).
+		Description(description).
+		Options(options...).
+		Value(value)
 }
 
 // createField creates the appropriate huh field based on parameter type

--- a/tests/cli/main.go
+++ b/tests/cli/main.go
@@ -87,6 +87,7 @@ func main() {
 	// Step 2: Build dynamic form based on template parameters
 	params := make(map[string]interface{})
 	paramValues := make(map[string]*string)
+	multiSelectValues := make(map[string]*[]string)
 
 	// Create form fields for each parameter
 	var formGroups []*huh.Group
@@ -94,22 +95,39 @@ func main() {
 	var visibleCount int
 
 	for _, p := range tmpl.Spec.Parameters {
-		// Create a string pointer to hold the value (including hidden params)
-		defaultVal := ""
-		if p.Default != nil {
-			defaultVal = fmt.Sprintf("%v", p.Default)
-		}
-		paramValues[p.Name] = &defaultVal
-
 		// Skip hidden parameters - they use their default value
 		if p.Hidden {
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
 			continue
 		}
 
-		visibleCount++
-		field := createField(p, paramValues[p.Name])
-		if field != nil {
-			currentFields = append(currentFields, field)
+		// Handle multiselect parameters
+		if p.Multiselect && len(p.Enum) > 0 {
+			defaults := defaultsToStringSlice(p.Default)
+			multiSelectValues[p.Name] = &defaults
+
+			visibleCount++
+			field := createMultiSelectField(p, multiSelectValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
+		} else {
+			// Create a string pointer to hold the value (including hidden params)
+			defaultVal := ""
+			if p.Default != nil {
+				defaultVal = fmt.Sprintf("%v", p.Default)
+			}
+			paramValues[p.Name] = &defaultVal
+
+			visibleCount++
+			field := createField(p, paramValues[p.Name])
+			if field != nil {
+				currentFields = append(currentFields, field)
+			}
 		}
 
 		// Group fields (max 5 per group for better UX)
@@ -136,7 +154,19 @@ func main() {
 	// Resolve random selections and pass all values as strings
 	rand.Seed(time.Now().UnixNano())
 	for _, p := range tmpl.Spec.Parameters {
-		strVal := *paramValues[p.Name]
+		// Handle multiselect values
+		if p.Multiselect && len(p.Enum) > 0 {
+			if vals, ok := multiSelectValues[p.Name]; ok && len(*vals) > 0 {
+				params[p.Name] = *vals
+			}
+			continue
+		}
+
+		valPtr, ok := paramValues[p.Name]
+		if !ok {
+			continue
+		}
+		strVal := *valPtr
 		if strVal == "" {
 			continue
 		}
@@ -184,10 +214,15 @@ func main() {
 		allParams[k] = v
 	}
 
-	// Convert all values to strings (KCL expects string types)
+	// Convert scalar values to strings; preserve slices for KCL list rendering
 	stringParams := make(map[string]interface{})
 	for k, v := range allParams {
-		stringParams[k] = fmt.Sprintf("%v", v)
+		switch v.(type) {
+		case []string, []interface{}:
+			stringParams[k] = v
+		default:
+			stringParams[k] = fmt.Sprintf("%v", v)
+		}
 	}
 
 	result := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
@@ -220,6 +255,46 @@ func main() {
 			fmt.Printf("💾 Saved to %s\n", savePath)
 		}
 	}
+}
+
+// defaultsToStringSlice converts a parameter's Default value to a []string.
+func defaultsToStringSlice(def interface{}) []string {
+	if def == nil {
+		return nil
+	}
+	switch v := def.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out
+	case []string:
+		return v
+	default:
+		return nil
+	}
+}
+
+// createMultiSelectField creates a multi-select huh field for parameters with multiselect: true.
+func createMultiSelectField(p claimtemplate.Parameter, value *[]string) huh.Field {
+	title := p.Title
+	if p.Required {
+		title += " *"
+	}
+
+	description := p.Description
+
+	var options []huh.Option[string]
+	for _, e := range p.Enum {
+		options = append(options, huh.NewOption(e, e))
+	}
+
+	return huh.NewMultiSelect[string]().
+		Title(title).
+		Description(description).
+		Options(options...).
+		Value(value)
 }
 
 // createField creates the appropriate huh field based on parameter type


### PR DESCRIPTION
## Summary

Closes #40

- Add `Multiselect bool` field to `Parameter` struct enabling `multiselect: true` in ClaimTemplate YAML
- Use `huh.NewMultiSelect[string]()` widget in CLI when a parameter has `multiselect: true` and enum values
- Format selected values as KCL list literals (`["a","b","c"]`) for `-D` flags in both OCI and non-OCI render paths
- Convert `[]interface{}` defaults to `[]string` for multiselect parameters in `BuildParameterValues`
- Mirror multiselect support in `tests/cli` and `tests/cli-api`
- Add `TestLoadClaimTemplate_Multiselect` test and `testdata/multiselect.yaml` fixture

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `TestLoadClaimTemplate_Multiselect` passes — verifies YAML parsing of `multiselect: true`
- [x] All `internal/render` tests pass — no regressions in KCL rendering
- [x] Manual: add a multiselect param to a template, run `go run . render`, verify multi-select widget appears and values render as KCL list

🤖 Generated with [Claude Code](https://claude.com/claude-code)