### PR TITLE
feat: fix/42-test-failures

### DIFF
--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -5,15 +5,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+// testdataDir returns the absolute path to the shared claimtemplate testdata directory.
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "failed to determine test file path")
+	return filepath.Join(filepath.Dir(file), "..", "claimtemplate", "testdata")
+}
+
 func TestHealthCheck(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request
@@ -30,7 +40,7 @@ func TestHealthCheck(t *testing.T) {
 
 func TestListTemplates(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request
@@ -55,11 +65,11 @@ func TestListTemplates(t *testing.T) {
 
 func TestGetTemplate(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/claim-templates/volumeclaim", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/claim-templates/volumeclaim-simple", nil)
 	w := httptest.NewRecorder()
 
 	// Handle request
@@ -79,7 +89,7 @@ func TestGetTemplate(t *testing.T) {
 
 func TestGetTemplate_NotFound(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request for non-existent template
@@ -95,7 +105,7 @@ func TestGetTemplate_NotFound(t *testing.T) {
 
 func TestOrderClaim(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request body
@@ -110,7 +120,7 @@ func TestOrderClaim(t *testing.T) {
 	// Create request
 	req := httptest.NewRequest(
 		http.MethodPost,
-		"/api/v1/claim-templates/volumeclaim/order",
+		"/api/v1/claim-templates/volumeclaim-simple/order",
 		bytes.NewReader(body),
 	)
 	req.Header.Set("Content-Type", "application/json")
@@ -134,7 +144,7 @@ func TestOrderClaim(t *testing.T) {
 
 func TestOrderClaim_NotFound(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request body
@@ -160,13 +170,13 @@ func TestOrderClaim_NotFound(t *testing.T) {
 
 func TestOrderClaim_InvalidBody(t *testing.T) {
 	// Create server
-	server, err := NewServer("internal/claimtemplate/testdata")
+	server, err := NewServer(testdataDir(t))
 	require.NoError(t, err)
 
 	// Create request with invalid JSON
 	req := httptest.NewRequest(
 		http.MethodPost,
-		"/api/v1/claim-templates/volumeclaim/order",
+		"/api/v1/claim-templates/volumeclaim-simple/order",
 		bytes.NewReader([]byte("invalid json")),
 	)
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/claimtemplate/loader_test.go
+++ b/internal/claimtemplate/loader_test.go
@@ -13,10 +13,10 @@ func TestLoadClaimTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, "ClaimTemplate", tmpl.Kind)
-	require.Equal(t, "volumeclaim", tmpl.Metadata.Name)
+	require.Equal(t, "volumeclaim-simple", tmpl.Metadata.Name)
 	require.Equal(t, "oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim", tmpl.Spec.Source)
 
-	require.Len(t, tmpl.Spec.Parameters, 4)
+	require.Len(t, tmpl.Spec.Parameters, 10)
 
 	param := tmpl.Spec.Parameters[0]
 	require.Equal(t, "templateName", param.Name)


### PR DESCRIPTION
                                                                                                
● Update(internal/claimtemplate/loader_test.go)      
  ⎿  Added 2 lines, removed 2 lines                                                              
      13    require.NoError(t, err)                                                              
      14                                                                                         
      15    require.Equal(t, "ClaimTemplate", tmpl.Kind)                                         
      16 -  require.Equal(t, "volumeclaim", tmpl.Metadata.Name)                           
      16 +  require.Equal(t, "volumeclaim-simple", tmpl.Metadata.Name)                           
      17    require.Equal(t, "oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim",   
          tmpl.Spec.Source)                                                                      
      18                                                                                  
      19 -  require.Len(t, tmpl.Spec.Parameters, 4)                                       
      19 +  require.Len(t, tmpl.Spec.Parameters, 9)                                         
      20                                                                                    
      21    param := tmpl.Spec.Parameters[0]                                              
      22    require.Equal(t, "templateName", param.Name)                                         

● Update(internal/api/handlers_test.go)
  ⎿  Added 2 lines
       5    "encoding/json"                                                               
       6    "net/http"                                                                    
       7    "net/http/httptest"                                                                  
       8 +  "path/filepath"                                                               
       9 +  "runtime"                                                                            
      10    "testing"                                                                     
      11                                                                                  
      12    "github.com/stretchr/testify/assert"                                            
                                                                                            
● Now add a helper function for test data path resolution and update all the test functions.

● Update(internal/api/handlers_test.go)                                                          
  ⎿  Added 9 lines, removed 1 line
      13    "github.com/stretchr/testify/require"                                                
      14  )                                                                               
      15                                                                                         
      16 +// testdataDir returns the absolute path to the shared claimtemplate testdata     
         +directory.                                                                             
      17 +func testdataDir(t *testing.T) string {                                           
      18 +  t.Helper()                                                                      
      19 +  _, file, _, ok := runtime.Caller(0)                                             
      20 +  require.True(t, ok, "failed to determine test file path")                       
      21 +  return filepath.Join(filepath.Dir(file), "..", "claimtemplate", "testdata")   
      22 +}                                                                               
      23 +                                                                                
      24  func TestHealthCheck(t *testing.T) {
      25    // Create server
      26 -  server, err := NewServer("internal/claimtemplate/testdata")                   
      26 +  server, err := NewServer(testdataDir(t))                                      
      27    require.NoError(t, err)
      28
      29    // Create request
  ⎿  Found 3 new diagnostic issues in 2 files (ctrl+o to expand)
                                 
● Good, the imports will be used once I update all the NewServer calls. Now let me update the
  remaining test functions.                                                                      
                                                                                                 
● Update(internal/api/handlers_test.go)                                                          
  ⎿  Added 6 lines, removed 6 lines                                                              
      40                                                                                         
      41  func TestListTemplates(t *testing.T) {                                            
      42    // Create server                                                                     
      43 -  server, err := NewServer("internal/claimtemplate/testdata")                        
      43 +  server, err := NewServer(testdataDir(t))                                             
      44    require.NoError(t, err)                                                              
      45                                                                                         
      46    // Create request                                                                    
     ...
      65
      66  func TestGetTemplate(t *testing.T) {
      67    // Create server
      68 -  server, err := NewServer("internal/claimtemplate/testdata")                   
      68 +  server, err := NewServer(testdataDir(t))                                      
      69    require.NoError(t, err)
      70
      71    // Create request
     ...
      89
      90  func TestGetTemplate_NotFound(t *testing.T) {
      91    // Create server
      92 -  server, err := NewServer("internal/claimtemplate/testdata")                   
      92 +  server, err := NewServer(testdataDir(t))                                      
      93    require.NoError(t, err)
      94
      95    // Create request for non-existent template
     ...
      105
      106  func TestOrderClaim(t *testing.T) {
      107    // Create server
      108 -  server, err := NewServer("internal/claimtemplate/testdata")                  
      108 +  server, err := NewServer(testdataDir(t))                                     
      109    require.NoError(t, err)
      110
      111    // Create request body
     ...
      144
      145  func TestOrderClaim_NotFound(t *testing.T) {
      146    // Create server
      147 -  server, err := NewServer("internal/claimtemplate/testdata")                  
      147 +  server, err := NewServer(testdataDir(t))                                     
      148    require.NoError(t, err)
      149
      150    // Create request body
     ...
      170
      171  func TestOrderClaim_InvalidBody(t *testing.T) {
      172    // Create server
      173 -  server, err := NewServer("internal/claimtemplate/testdata")                  
      173 +  server, err := NewServer(testdataDir(t))                                     
      174    require.NoError(t, err)
      175
      176    // Create request with invalid JSON

● Now update the URL paths from volumeclaim to volumeclaim-simple to match the fixture's
  metadata.name.
                                                                                                 
● Update(internal/api/handlers_test.go)
  ⎿  Added 3 lines, removed 3 lines                                                              
      69    require.NoError(t, err)                                                              
      70                                                                                  
      71    // Create request                                                                    
      72 -  req := httptest.NewRequest(http.MethodGet,                                         
         -"/api/v1/claim-templates/volumeclaim", nil)                                            
      72 +  req := httptest.NewRequest(http.MethodGet,                                         
         +"/api/v1/claim-templates/volumeclaim-simple", nil)                              
      73    w := httptest.NewRecorder()
      74
      75    // Handle request
     ...
      120    // Create request
      121    req := httptest.NewRequest(
      122      http.MethodPost,
      123 -    "/api/v1/claim-templates/volumeclaim/order",                               
      123 +    "/api/v1/claim-templates/volumeclaim-simple/order",                        
      124      bytes.NewReader(body),
      125    )
      126    req.Header.Set("Content-Type", "application/json")
     ...
      176    // Create request with invalid JSON
      177    req := httptest.NewRequest(
      178      http.MethodPost,
      179 -    "/api/v1/claim-templates/volumeclaim/order",                               
      179 +    "/api/v1/claim-templates/volumeclaim-simple/order",                        
      180      bytes.NewReader([]byte("invalid json")),
      181    )
      182    req.Header.Set("Content-Type", "application/json")

● Now let me run the tests to verify both fixes.

● Bash(go test ./internal/claimtemplate/ -run TestLoadClaimTemplate -v 2>&1)                     
  ⎿  Error: Exit code 1
     === RUN   TestLoadClaimTemplate                                                             
         loader_test.go:19:                                                                    
                Error                                                                            
     Trace:     /home/sthings/projects/claim-machinery-api/internal/claimtemplate/loader_test.go:
                Error:          "[{templateName Template  string simple false [demo database simp
     false false false  <nil> <nil>} {name Resource Name  string simple-storage false [] false   
     false false ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ <nil> <nil>} {namespace Namespace  string defaul
      true [] false false false ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ <nil> <nil>} {pvcName PVC Name  
     string app-data false [] false false false ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ <nil> <nil>}     
     {storage Storage Size  string 20Gi true [] false false false ^[0-9]+(Gi|Mi|Ti)$ <nil> <nil>}
     {storageClassName Storage Class  string standard false [] false false false  <nil> <nil>}
     {accessModes Access Modes  array [ReadWriteOnce] false [] false false false  <nil> <nil>}
     {volumeMode Volume Mode  string Filesystem false [Filesystem Block] false false false  <nil>
     <nil>} {providerConfigRef Provider Config  string default-k8s false [] false false false
     <nil> <nil>} {description Description  string A simple persistent volume claim for
     application data false [] false false false  <nil> <nil>}]" should have 9 item(s), but has 1
                Test:           TestLoadClaimTemplate
     --- FAIL: TestLoadClaimTemplate (0.00s)
     === RUN   TestLoadClaimTemplate_Multiselect
     --- PASS: TestLoadClaimTemplate_Multiselect (0.00s)
     FAIL




     … +2 lines (ctrl+o to see all)

● Bash(go test ./internal/api/ -v 2>&1)
  ⎿  Error: Sibling tool call errored

● The fixture actually has 10 parameters (I miscounted — there's a description parameter at the
  end). Let me fix the count and re-run both test suites.
                                                                                                 
● Update(internal/claimtemplate/loader_test.go)
  ⎿  Added 1 line, removed 1 line                                                                
      16    require.Equal(t, "volumeclaim-simple", tmpl.Metadata.Name)                           
      17    require.Equal(t, "oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim",   
          tmpl.Spec.Source)                                                                      
      18                                                                                       
      19 -  require.Len(t, tmpl.Spec.Parameters, 9)                                              
      19 +  require.Len(t, tmpl.Spec.Parameters, 10)                                           
      20
      21    param := tmpl.Spec.Parameters[0]
      22    require.Equal(t, "templateName", param.Name)

● Bash(go test ./internal/claimtemplate/ -run TestLoadClaimTemplate -v 2>&1)
  ⎿  === RUN   TestLoadClaimTemplate
     --- PASS: TestLoadClaimTemplate (0.00s)                                                     
     === RUN   TestLoadClaimTemplate_Multiselect
     … +3 lines (ctrl+o to expand)                                                               
                                                                                                 
● Bash(go test ./internal/api/ -v 2>&1)
  ⎿ === RUN   TestHealthCheck                                                                    
    2026/02/04 07:17:15 GET /health -> 200 (27.573µs) reqId=7a8635441528043c49128e0869bc5eb4     
     remote=192.0.2.1:1234 ua="" bytes=55
    … +37 lines (ctrl+o to expand)                                                               
                                                                                                 
                                                                                                 
● All tests pass. Here's a summary of the fixes:                                                 
                                                                                                 
  Failure 1 — TestLoadClaimTemplate in loader_test.go:                                           
  - Updated expected metadata.name from "volumeclaim" to "volumeclaim-simple" to match the  
  fixture                                                                                        
  - Updated expected parameter count from 4 to 10 to match the fixture (it has 10 parameters, not
   9 as the issue stated)                                                                        
                                                                                                 
  Failure 2 — API handler tests in handlers_test.go:                                             
  - Added a testdataDir() helper that uses runtime.Caller to compute the absolute path to        
  internal/claimtemplate/testdata, so the path resolves correctly regardless of the go test
  working directory                                                                              
  - Updated all URL paths from /api/v1/claim-templates/volumeclaim to
  /api/v1/claim-templates/volumeclaim-simple to match the fixture's metadata.name

✻ Crunched for 1m 11s

❯ create branch from issue, commit and pr                                                        
                                          
● Bash(git status)                                                                               
  ⎿  On branch main                                                                            
     Your branch is up to date with 'origin/main'.                                               
     … +7 lines (ctrl+o to expand)
                                                                                                 
● Bash(git diff)                                                                                 
  ⎿  diff --git a/internal/api/handlers_test.go b/internal/api/handlers_test.go
     index 7906bda..74cb976 100644                                                               
     --- a/internal/api/handlers_test.go                    
     … +124 lines (ctrl+o to expand)                                                             
                                                                                                 
● Bash(git log --oneline -5)
  ⎿  d34bfc9 feat: feat/add-claim-field-doc                                                      
     23337f5 feat: add multiselect support for enum parameters (#40)                             
     86336b5 feat: main    
     … +2 lines (ctrl+o to expand)                                                               
                                                  