### PR TITLE
feat: resilient KCL error handling and remote profile hot reload

### DIFF
--- a/cmd/render.go
+++ b/cmd/render.go
@@ -300,7 +300,11 @@ func runRender(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	result := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
+	result, err := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ Rendering failed: %v\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println(successStyle.Render("\n✅ Rendered successfully!"))
 	fmt.Println(yamlStyle.Render(result))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -143,8 +144,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 		}
 	}()
 
-	// Start config auto-reload watcher if profile is a local file
-	if profilePath != "" && !strings.HasPrefix(profilePath, "http://") && !strings.HasPrefix(profilePath, "https://") {
+	// Start config auto-reload watcher for profile changes
+	if profilePath != "" {
 		go watchProfileForReload(stopCh, server, profilePath, enableTemplatesDir, templatesDir)
 	}
 
@@ -178,11 +179,14 @@ func runServer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// watchProfileForReload periodically checks the profile file for changes and
+// watchProfileForReload periodically checks the profile for changes and
 // reloads templates into the running server when a change is detected.
+// Supports both local file paths and remote HTTP/HTTPS URLs.
 func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePath string, enableTemplatesDir bool, templatesDir string) {
 	const pollInterval = 10 * time.Second
-	lastHash := fileHash(profilePath)
+	isRemote := strings.HasPrefix(profilePath, "http://") || strings.HasPrefix(profilePath, "https://")
+
+	lastHash := profileHash(profilePath, isRemote)
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -192,12 +196,12 @@ func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePa
 		case <-stopCh:
 			return
 		case <-ticker.C:
-			currentHash := fileHash(profilePath)
+			currentHash := profileHash(profilePath, isRemote)
 			if currentHash == lastHash {
 				continue
 			}
 			lastHash = currentHash
-			log.Println("Profile file changed, reloading templates...")
+			log.Printf("Profile changed, reloading templates... (source: %s)", profilePath)
 
 			templates, err := loadMergedTemplates(enableTemplatesDir, templatesDir, profilePath)
 			if err != nil {
@@ -243,7 +247,16 @@ func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath stri
 	return result, nil
 }
 
-// fileHash returns the SHA-256 hex digest of a file, or empty string on error.
+// profileHash returns the SHA-256 hex digest of a profile source (local file or remote URL).
+// Returns empty string on error.
+func profileHash(path string, isRemote bool) string {
+	if isRemote {
+		return remoteHash(path)
+	}
+	return fileHash(path)
+}
+
+// fileHash returns the SHA-256 hex digest of a local file, or empty string on error.
 func fileHash(path string) string {
 	f, err := os.Open(path)
 	if err != nil {
@@ -252,6 +265,27 @@ func fileHash(path string) string {
 	defer f.Close()
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// remoteHash fetches a URL and returns the SHA-256 hex digest of the response body,
+// or empty string on error.
+func remoteHash(url string) string {
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		log.Printf("Failed to fetch profile URL for hash check: %v", err)
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		log.Printf("Profile URL returned status %s during hash check", resp.Status)
+		return ""
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, resp.Body); err != nil {
 		return ""
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))

--- a/internal/app/renderer.go
+++ b/internal/app/renderer.go
@@ -63,7 +63,10 @@ func RenderTemplate(t *claimtemplate.ClaimTemplate, customParams ...map[string]i
 	}
 
 	// Render using KCL from OCI source
-	result := render.RenderKCLFromOCI(t.Spec.Source, t.Spec.Tag, params)
+	result, err := render.RenderKCLFromOCI(t.Spec.Source, t.Spec.Tag, params)
+	if err != nil {
+		return "", fmt.Errorf("rendering failed for template %s: %w", t.Metadata.Name, err)
+	}
 
 	if result == "" {
 		return "", fmt.Errorf("rendering produced empty result for template %s", t.Metadata.Name)

--- a/internal/render/kcl.go
+++ b/internal/render/kcl.go
@@ -3,7 +3,6 @@ package render
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -14,12 +13,12 @@ import (
 
 func RenderKCL(
 	kclFile string,
-	allAnswers map[string]interface{}) string {
+	allAnswers map[string]interface{}) (string, error) {
 
 	// READ MAIN KCL FILE
 	content, err := os.ReadFile(kclFile)
 	if err != nil {
-		log.Fatalf("Error reading KCL file: %v", err)
+		return "", fmt.Errorf("error reading KCL file: %w", err)
 	}
 
 	// OUTPUT ALL ANSWERS + MODIFY
@@ -29,7 +28,7 @@ func RenderKCL(
 
 	values := convertToOptionStrings(allAnswers)
 
-	// // Prepare KCL options with explicit key-value pairs
+	// Prepare KCL options with explicit key-value pairs
 	opts := []kcl.Option{
 		kcl.WithCode(string(content)),
 		kcl.WithOptions(values...),
@@ -38,11 +37,11 @@ func RenderKCL(
 	// Execute KCL
 	result, err := kcl.Run(kclFile, opts...)
 	if err != nil {
-		log.Fatalf("KCL execution failed: %v", err)
+		return "", fmt.Errorf("KCL execution failed: %w", err)
 	}
 
 	// Output generated YAML
-	return replaceTripleQuotes(result.GetRawYamlResult())
+	return replaceTripleQuotes(result.GetRawYamlResult()), nil
 }
 
 // RenderKCLToFile renders KCL and writes output to both stdout and file
@@ -52,10 +51,13 @@ func RenderKCLToFile(
 	destination string) (string, error) {
 
 	// Get rendered YAML
-	yaml := RenderKCL(kclFile, allAnswers)
+	yaml, err := RenderKCL(kclFile, allAnswers)
+	if err != nil {
+		return "", fmt.Errorf("failed to render KCL: %w", err)
+	}
 
 	// Write to file
-	err := os.WriteFile(destination, []byte(yaml), 0644)
+	err = os.WriteFile(destination, []byte(yaml), 0644)
 	if err != nil {
 		return yaml, fmt.Errorf("failed to write YAML to file %s: %w", destination, err)
 	}
@@ -70,7 +72,7 @@ func RenderKCLToFile(
 func RenderKCLFromOCI(
 	ociSource string,
 	tag string,
-	allAnswers map[string]interface{}) string {
+	allAnswers map[string]interface{}) (string, error) {
 
 	// Build command: kcl run <oci-source> -D key=value ...
 	args := []string{"run", "--quiet"}
@@ -97,11 +99,11 @@ func RenderKCLFromOCI(
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		log.Fatalf("KCL execution from OCI source failed: %v\nStderr: %s", err, stderr.String())
+		return "", fmt.Errorf("KCL execution from OCI source failed: %w\nStderr: %s", err, stderr.String())
 	}
 
 	// Output generated YAML
-	return replaceTripleQuotes(stdout.String())
+	return replaceTripleQuotes(stdout.String()), nil
 }
 
 // RenderKCLFromOCIToFile renders KCL from OCI source and writes output to both stdout and file
@@ -112,10 +114,13 @@ func RenderKCLFromOCIToFile(
 	destination string) (string, error) {
 
 	// Get rendered YAML
-	yaml := RenderKCLFromOCI(ociSource, tag, allAnswers)
+	yaml, err := RenderKCLFromOCI(ociSource, tag, allAnswers)
+	if err != nil {
+		return "", fmt.Errorf("failed to render KCL from OCI: %w", err)
+	}
 
 	// Write to file
-	err := os.WriteFile(destination, []byte(yaml), 0644)
+	err = os.WriteFile(destination, []byte(yaml), 0644)
 	if err != nil {
 		return yaml, fmt.Errorf("failed to write YAML to file %s: %w", destination, err)
 	}

--- a/internal/render/kcl_test.go
+++ b/internal/render/kcl_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReplaceTripleQuotes(t *testing.T) {
@@ -170,7 +171,8 @@ result = {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := RenderKCL(kclFile, tt.answers)
+			result, err := RenderKCL(kclFile, tt.answers)
+			require.NoError(t, err)
 			assert.NotEmpty(t, result, "Expected non-empty YAML output")
 			assert.Contains(t, result, "result:", "Expected 'result:' in output")
 		})
@@ -245,7 +247,8 @@ func TestRenderKCLFromOCI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// This test will execute KCL against actual OCI source
 			// Comment out if offline - it requires internet access
-			result := RenderKCLFromOCI(tt.oci, tt.tag, tt.answers)
+			result, err := RenderKCLFromOCI(tt.oci, tt.tag, tt.answers)
+			require.NoError(t, err)
 			assert.NotEmpty(t, result, "Expected non-empty YAML output from OCI source")
 		})
 	}

--- a/tests/cli/main.go
+++ b/tests/cli/main.go
@@ -225,7 +225,11 @@ func main() {
 		}
 	}
 
-	result := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
+	result, err := render.RenderKCLFromOCI(tmpl.Spec.Source, tmpl.Spec.Tag, stringParams)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\n❌ Rendering failed: %v\n", err)
+		os.Exit(1)
+	}
 
 	fmt.Println(successStyle.Render("\n✅ Rendered successfully!"))
 	fmt.Println(yamlStyle.Render(result))


### PR DESCRIPTION
## Summary
- **Fix API crash on KCL errors:** Replace `log.Fatalf` calls in `RenderKCL` and `RenderKCLFromOCI` with proper `(string, error)` returns. KCL failures now produce HTTP 500 responses instead of killing the server process.
- **Remote profile hot reload:** Extend the config watcher to support HTTP/HTTPS profile URLs by fetching and hashing the remote response body every poll cycle. Previously only local file profiles were watched.
- Update all callers (API handler, CLI commands, tests) for the new error signatures.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/api/... ./internal/app/... ./internal/claimtemplate/...` passes
- [ ] Manual: start server with remote profile URL, change remote profile, verify templates reload
- [ ] Manual: trigger a KCL render error via `/order` endpoint, verify HTTP 500 response (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)