### PR TITLE
feat: send homerun2 notification on successful template order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,11 @@ internal/
   app/                   Business logic: template loading, profile parsing, parameter merging, rendering orchestration
   render/                KCL execution engine (OCI-based via CLI, file-based via Go SDK)
   claimtemplate/         Domain model: ClaimTemplate struct, YAML deserialization
+  notify/                Homerun2 (omni-pitcher) notification sender
   version/               Build metadata (set via ldflags)
 ```
 
-**Request flow:** HTTP handler -> `app.BuildParameterValues` (merge defaults + request params) -> `app.RenderTemplate` -> `render.KCL` execution -> JSON response
+**Request flow:** HTTP handler -> `app.BuildParameterValues` (merge defaults + request params) -> `app.RenderTemplate` -> `render.KCL` execution -> JSON response -> (async) `notify.SendHomerunMessage`
 
 **Template loading:** Templates come from two sources merged at startup:
 1. Directory scan (`TEMPLATES_DIR` env var / `--templates-dir` flag) - loads all YAML files
@@ -76,6 +77,9 @@ Responses use Kubernetes-style format with `apiVersion: api.claim-machinery.io/v
 | `DEBUG` | Enable debug logging (`1`/`true`/`yes`) | off |
 | `ENABLE_TEST_ROUTES` | Enable `/__test/*` endpoints | off |
 | `LOG_FORMAT` | Log format (`json` or text) | text |
+| `ENABLE_HOMERUN` | Enable homerun2 notifications (`true`/`1`/`yes`) | off |
+| `HOMERUN_URL` | Omni-pitcher base URL (e.g. `https://pitcher.example.com`) | - |
+| `HOMERUN_AUTH_TOKEN` | Bearer token for pitcher `/pitch` endpoint | - |
 
 ## Testing Conventions
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Backstage-compatible API for discovering, managing, and rendering KCL-based Cr
 | Template Discovery | Browse and search KCL-based Crossplane claim templates |
 | Template Details | Get schema information including parameters, validation rules, and UI hints |
 | Claim Rendering | Render claims with custom parameters using KCL |
+| Homerun2 Notifications | Optional event notifications via homerun2 omni-pitcher on claim orders |
 | Backstage Integration | Native support for Backstage Software Catalog |
 | OCI Support | Load templates from OCI registries |
 | Parameter Schema | Exposes parameter metadata (types, enums, patterns, defaults) for client-side validation |
@@ -148,6 +149,14 @@ curl -s -X POST http://localhost:8080/api/v1/claim-templates/volumeclaim/order \
 
 Passing an empty body `{}` renders with all default values.
 
+The order request supports an optional `author` field for tracking who ordered the resource:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/claim-templates/volumeclaim/order \
+  -H "Content-Type: application/json" \
+  -d '{"author": "jane.doe", "parameters": {"namespace": "production"}}'
+```
+
 <details>
 <summary><strong>More Examples (HarborProject)</strong></summary>
 
@@ -224,6 +233,11 @@ export TEMPLATE_PROFILE_PATH=https://example.com/profile.yaml  # or HTTP URL
 export ENABLE_TEMPLATES_DIR=true  # enable loading from templates directory
 export PORT=9090
 export LOG_FORMAT=json   # default: text
+
+# Homerun2 notifications (optional)
+export ENABLE_HOMERUN=true
+export HOMERUN_URL=https://pitcher.example.com
+export HOMERUN_AUTH_TOKEN=your-bearer-token
 ```
 
 **Priority:** Flag > Environment Variable > Default
@@ -291,6 +305,39 @@ Enable debug logging to see parameter processing:
 ```bash
 DEBUG=1 go run main.go
 ```
+
+</details>
+
+<details>
+<summary><strong>Homerun2 Notifications</strong></summary>
+
+When enabled, the API sends a notification to [homerun2 omni-pitcher](https://stuttgart-things.github.io/homerun2-omni-pitcher/) on every successful claim order. This provides visibility into who ordered which resource.
+
+**Enable:**
+
+```bash
+export ENABLE_HOMERUN=true
+export HOMERUN_URL=https://pitcher.example.com
+export HOMERUN_AUTH_TOKEN=your-bearer-token  # optional
+```
+
+Both `ENABLE_HOMERUN` and `HOMERUN_URL` must be set for notifications to fire. This lets you keep the URL configured while toggling notifications on/off.
+
+**Example notification sent to pitcher:**
+
+```json
+{
+  "title": "Claim Order: postgresql",
+  "message": "Template 'PostgreSQL Database Claim' ordered successfully.\n\nParameters:\n  instanceClass: db.t3.medium\n  namespace: production",
+  "severity": "success",
+  "author": "jane.doe",
+  "system": "claim-machinery-api",
+  "tags": "claim-order,database,crossplane,postgresql",
+  "artifacts": "oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim:0.1.1"
+}
+```
+
+Notifications are sent asynchronously and never block the API response. On failure, a warning is logged but the order still succeeds.
 
 </details>
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stuttgart-things/claim-machinery-api/internal/api"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/notify"
 )
 
 var serverCmd = &cobra.Command{
@@ -116,6 +117,15 @@ func runServer(cmd *cobra.Command, args []string) error {
 	}
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
+	}
+
+	// Configure homerun2 notifications
+	homerunCfg := notify.LoadHomerunConfig()
+	server.SetHomerunConfig(homerunCfg)
+	if homerunCfg.Enabled {
+		fmt.Printf("📢 Homerun notifications enabled (URL: %s)\n", homerunCfg.URL)
+	} else {
+		fmt.Println("📢 Homerun notifications disabled")
 	}
 
 	// Start server with automatic restart on crash

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -8,11 +8,13 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/notify"
 )
 
 // OrderRequest represents a claim order request
 type OrderRequest struct {
 	Parameters map[string]interface{} `json:"parameters"`
+	Author     string                 `json:"author,omitempty"`
 }
 
 // OrderResponse represents a rendered claim response
@@ -121,6 +123,21 @@ func (s *Server) orderClaim(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	// Send homerun notification asynchronously
+	go func() {
+		msg := notify.BuildOrderMessage(
+			tmpl.Metadata.Name,
+			tmpl.Metadata.Title,
+			tmpl.Spec.Type,
+			tmpl.Metadata.Tags,
+			tmpl.Spec.Source,
+			tmpl.Spec.Tag,
+			params,
+			req.Author,
+		)
+		notify.SendHomerunMessage(s.homerun, msg)
+	}()
 
 	// Return success response
 	response := OrderResponse{

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/notify"
 	"github.com/stuttgart-things/claim-machinery-api/internal/version"
 )
 
@@ -22,6 +23,7 @@ type Server struct {
 	http      *http.Server
 	mu        sync.RWMutex
 	templates map[string]*claimtemplate.ClaimTemplate
+	homerun   notify.HomerunConfig
 }
 
 // NewServer creates and initializes a new HTTP server
@@ -143,6 +145,11 @@ func (s *Server) Start() error {
 func (s *Server) Stop(ctx context.Context) error {
 	log.Println("⏹️  Shutting down HTTP server...")
 	return s.http.Shutdown(ctx)
+}
+
+// SetHomerunConfig sets the homerun notification configuration.
+func (s *Server) SetHomerunConfig(cfg notify.HomerunConfig) {
+	s.homerun = cfg
 }
 
 // UpdateTemplates replaces the in-memory template map with the given templates.

--- a/internal/notify/homerun.go
+++ b/internal/notify/homerun.go
@@ -1,0 +1,159 @@
+package notify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// HomerunMessage represents a message for the homerun2 omni-pitcher /pitch endpoint.
+type HomerunMessage struct {
+	Title           string `json:"title"`
+	Message         string `json:"message"`
+	Severity        string `json:"severity,omitempty"`
+	Author          string `json:"author,omitempty"`
+	Timestamp       string `json:"timestamp,omitempty"`
+	System          string `json:"system,omitempty"`
+	Tags            string `json:"tags,omitempty"`
+	AssigneeAddress string `json:"assigneeaddress,omitempty"`
+	AssigneeName    string `json:"assigneename,omitempty"`
+	Artifacts       string `json:"artifacts,omitempty"`
+	Url             string `json:"url,omitempty"`
+}
+
+// HomerunConfig holds the configuration for homerun2 notifications.
+type HomerunConfig struct {
+	Enabled   bool
+	URL       string
+	AuthToken string
+}
+
+// LoadHomerunConfig reads homerun configuration from environment variables.
+func LoadHomerunConfig() HomerunConfig {
+	enabled := isTruthy(os.Getenv("ENABLE_HOMERUN"))
+	url := os.Getenv("HOMERUN_URL")
+	token := os.Getenv("HOMERUN_AUTH_TOKEN")
+
+	return HomerunConfig{
+		Enabled:   enabled && url != "",
+		URL:       url,
+		AuthToken: token,
+	}
+}
+
+// SendHomerunMessage sends a message to the homerun2 omni-pitcher.
+// It is safe to call even when homerun is disabled (no-op).
+// On failure it logs a warning but never returns an error.
+func SendHomerunMessage(cfg HomerunConfig, msg HomerunMessage) {
+	if !cfg.Enabled {
+		return
+	}
+
+	if msg.Timestamp == "" {
+		msg.Timestamp = time.Now().Format(time.RFC3339)
+	}
+	if msg.System == "" {
+		msg.System = "claim-machinery-api"
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		log.Printf("homerun: failed to marshal message: %v", err)
+		return
+	}
+
+	pitchURL := strings.TrimRight(cfg.URL, "/") + "/pitch"
+
+	req, err := http.NewRequest(http.MethodPost, pitchURL, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("homerun: failed to create request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if cfg.AuthToken != "" {
+		req.Header.Set("Authorization", "Bearer "+cfg.AuthToken)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Printf("homerun: failed to send message: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Printf("homerun: pitcher returned status %s", resp.Status)
+		return
+	}
+
+	log.Printf("homerun: notification sent (%s)", msg.Title)
+}
+
+// BuildOrderMessage constructs a HomerunMessage for a successful template order.
+func BuildOrderMessage(
+	templateName string,
+	templateTitle string,
+	templateType string,
+	templateTags []string,
+	templateSource string,
+	templateTag string,
+	params map[string]interface{},
+	author string,
+) HomerunMessage {
+	if author == "" {
+		author = "claim-machinery-api"
+	}
+
+	// Build parameter summary
+	var paramLines []string
+	for k, v := range params {
+		paramLines = append(paramLines, fmt.Sprintf("  %s: %v", k, v))
+	}
+
+	title := templateTitle
+	if title == "" {
+		title = templateName
+	}
+
+	msgBody := fmt.Sprintf("Template '%s' ordered successfully.", title)
+	if len(paramLines) > 0 {
+		msgBody += "\n\nParameters:\n" + strings.Join(paramLines, "\n")
+	}
+
+	// Build tags: claim-order + type + template tags
+	tagParts := []string{"claim-order"}
+	if templateType != "" {
+		tagParts = append(tagParts, templateType)
+	}
+	tagParts = append(tagParts, templateTags...)
+
+	// Build artifacts from OCI source
+	artifacts := templateSource
+	if templateTag != "" {
+		artifacts += ":" + templateTag
+	}
+
+	return HomerunMessage{
+		Title:    "Claim Order: " + templateName,
+		Message:  msgBody,
+		Severity: "success",
+		Author:   author,
+		System:   "claim-machinery-api",
+		Tags:     strings.Join(tagParts, ","),
+		Artifacts: artifacts,
+	}
+}
+
+func isTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}

--- a/internal/notify/homerun_test.go
+++ b/internal/notify/homerun_test.go
@@ -1,0 +1,162 @@
+package notify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTruthy(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"true", true},
+		{"True", true},
+		{"TRUE", true},
+		{"1", true},
+		{"yes", true},
+		{"YES", true},
+		{"false", false},
+		{"0", false},
+		{"no", false},
+		{"", false},
+		{"  true  ", true},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, isTruthy(tt.input), "isTruthy(%q)", tt.input)
+	}
+}
+
+func TestLoadHomerunConfig(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		t.Setenv("ENABLE_HOMERUN", "")
+		t.Setenv("HOMERUN_URL", "")
+		t.Setenv("HOMERUN_AUTH_TOKEN", "")
+
+		cfg := LoadHomerunConfig()
+		assert.False(t, cfg.Enabled)
+	})
+
+	t.Run("enabled requires both flag and URL", func(t *testing.T) {
+		t.Setenv("ENABLE_HOMERUN", "true")
+		t.Setenv("HOMERUN_URL", "")
+
+		cfg := LoadHomerunConfig()
+		assert.False(t, cfg.Enabled)
+	})
+
+	t.Run("enabled with URL", func(t *testing.T) {
+		t.Setenv("ENABLE_HOMERUN", "1")
+		t.Setenv("HOMERUN_URL", "https://pitcher.example.com")
+		t.Setenv("HOMERUN_AUTH_TOKEN", "secret-token")
+
+		cfg := LoadHomerunConfig()
+		assert.True(t, cfg.Enabled)
+		assert.Equal(t, "https://pitcher.example.com", cfg.URL)
+		assert.Equal(t, "secret-token", cfg.AuthToken)
+	})
+}
+
+func TestSendHomerunMessage(t *testing.T) {
+	t.Run("no-op when disabled", func(t *testing.T) {
+		cfg := HomerunConfig{Enabled: false}
+		// Should not panic or error
+		SendHomerunMessage(cfg, HomerunMessage{Title: "test"})
+	})
+
+	t.Run("sends POST to pitcher", func(t *testing.T) {
+		var received HomerunMessage
+		var gotAuth string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/pitch", r.URL.Path)
+			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+			gotAuth = r.Header.Get("Authorization")
+
+			err := json.NewDecoder(r.Body).Decode(&received)
+			require.NoError(t, err)
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"status":"success"}`))
+		}))
+		defer srv.Close()
+
+		cfg := HomerunConfig{
+			Enabled:   true,
+			URL:       srv.URL,
+			AuthToken: "test-token",
+		}
+
+		msg := HomerunMessage{
+			Title:    "Claim Order: postgresql",
+			Message:  "Template ordered",
+			Severity: "success",
+			Author:   "test-user",
+			System:   "claim-machinery-api",
+			Tags:     "claim-order,database",
+		}
+
+		SendHomerunMessage(cfg, msg)
+
+		assert.Equal(t, "Claim Order: postgresql", received.Title)
+		assert.Equal(t, "success", received.Severity)
+		assert.Equal(t, "test-user", received.Author)
+		assert.Equal(t, "Bearer test-token", gotAuth)
+		assert.NotEmpty(t, received.Timestamp)
+	})
+
+	t.Run("sends without auth token", func(t *testing.T) {
+		var gotAuth string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		cfg := HomerunConfig{Enabled: true, URL: srv.URL}
+		SendHomerunMessage(cfg, HomerunMessage{Title: "test"})
+
+		assert.Empty(t, gotAuth)
+	})
+}
+
+func TestBuildOrderMessage(t *testing.T) {
+	msg := BuildOrderMessage(
+		"postgresql",
+		"PostgreSQL Database Claim",
+		"database",
+		[]string{"crossplane", "postgresql"},
+		"oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim",
+		"0.1.1",
+		map[string]interface{}{
+			"instanceClass": "db.t3.medium",
+			"namespace":     "production",
+		},
+		"",
+	)
+
+	assert.Equal(t, "Claim Order: postgresql", msg.Title)
+	assert.Contains(t, msg.Message, "PostgreSQL Database Claim")
+	assert.Contains(t, msg.Message, "Parameters:")
+	assert.Equal(t, "success", msg.Severity)
+	assert.Equal(t, "claim-machinery-api", msg.Author)
+	assert.Equal(t, "claim-machinery-api", msg.System)
+	assert.Equal(t, "claim-order,database,crossplane,postgresql", msg.Tags)
+	assert.Equal(t, "oci://ghcr.io/stuttgart-things/claim-xplane-volumeclaim:0.1.1", msg.Artifacts)
+}
+
+func TestBuildOrderMessage_WithAuthor(t *testing.T) {
+	msg := BuildOrderMessage("test", "", "", nil, "oci://test", "", nil, "custom-user")
+
+	assert.Equal(t, "custom-user", msg.Author)
+	assert.Equal(t, "Claim Order: test", msg.Title)
+	assert.Contains(t, msg.Message, "test")
+	assert.NotContains(t, msg.Message, "Parameters:")
+}


### PR DESCRIPTION
## Summary
- Add `internal/notify` package with homerun2 omni-pitcher integration
- Send async notification on every successful `/order` request with template name, parameters, tags, and OCI source
- New `author` field on `OrderRequest` for tracking who ordered the resource
- Controlled by `ENABLE_HOMERUN`, `HOMERUN_URL`, `HOMERUN_AUTH_TOKEN` env vars (opt-in, disabled by default)
- Notifications never block the API response or fail the order
- Full test coverage for notify package (config loading, HTTP sending, message building)
- Updated CLAUDE.md and README.md with new env vars, architecture, and usage docs

Closes #77

## Test plan
- [x] `go build ./...` compiles
- [x] `go test ./internal/...` passes (including new notify tests)
- [ ] Manual: enable homerun, order a template, verify notification arrives at pitcher
- [ ] Manual: disable homerun, verify no notification sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)