### PR TITLE
feat: add secrets[] field to ClaimTemplate spec

### DIFF
--- a/internal/claimtemplate/claimtemplate.go
+++ b/internal/claimtemplate/claimtemplate.go
@@ -23,10 +23,19 @@ type ClaimTemplateMetadata struct {
 }
 
 type ClaimTemplateSpec struct {
-	Type       string      `yaml:"type" json:"type"`
-	Source     string      `yaml:"source" json:"source"`
-	Tag        string      `yaml:"tag,omitempty" json:"tag,omitempty"`
-	Parameters []Parameter `yaml:"parameters" json:"parameters"`
+	Type       string           `yaml:"type" json:"type"`
+	Source     string           `yaml:"source" json:"source"`
+	Tag        string           `yaml:"tag,omitempty" json:"tag,omitempty"`
+	Parameters []Parameter      `yaml:"parameters" json:"parameters"`
+	Secrets    []SecretTemplate `yaml:"secrets,omitempty" json:"secrets,omitempty"`
+}
+
+// SecretTemplate defines a Kubernetes Secret that accompanies the rendered template.
+// Secret values are collected and encrypted client-side (SOPS/age) — they never pass through the API.
+type SecretTemplate struct {
+	Name       string      `yaml:"name" json:"name"`             // supports Go template expressions e.g. "{{.secretName}}"
+	Namespace  string      `yaml:"namespace" json:"namespace"`   // supports Go template expressions
+	Parameters []Parameter `yaml:"parameters" json:"parameters"` // secret key definitions
 }
 
 type Parameter struct {

--- a/internal/claimtemplate/loader_test.go
+++ b/internal/claimtemplate/loader_test.go
@@ -50,3 +50,32 @@ func TestLoadClaimTemplate_Multiselect(t *testing.T) {
 	require.Equal(t, "name", name.Name)
 	require.False(t, name.Multiselect)
 }
+
+func TestLoadClaimTemplate_WithSecrets(t *testing.T) {
+	tmpl, err := claimtemplate.LoadClaimTemplate("testdata/with-secrets.yaml")
+	require.NoError(t, err)
+
+	require.Equal(t, "ClaimTemplate", tmpl.Kind)
+	require.Equal(t, "app-with-secrets", tmpl.Metadata.Name)
+	require.Len(t, tmpl.Spec.Parameters, 2)
+
+	// Secrets should be parsed
+	require.Len(t, tmpl.Spec.Secrets, 1)
+
+	secret := tmpl.Spec.Secrets[0]
+	require.Equal(t, "{{.secretName}}", secret.Name)
+	require.Equal(t, "{{.secretNamespace}}", secret.Namespace)
+	require.Len(t, secret.Parameters, 2)
+
+	require.Equal(t, "API_TOKEN", secret.Parameters[0].Name)
+	require.True(t, secret.Parameters[0].Required)
+	require.Equal(t, "DB_PASSWORD", secret.Parameters[1].Name)
+	require.True(t, secret.Parameters[1].Required)
+}
+
+func TestLoadClaimTemplate_WithoutSecrets(t *testing.T) {
+	// Existing templates without secrets should still load fine
+	tmpl, err := claimtemplate.LoadClaimTemplate("testdata/volumeclaim.yaml")
+	require.NoError(t, err)
+	require.Nil(t, tmpl.Spec.Secrets)
+}

--- a/internal/claimtemplate/testdata/with-secrets.yaml
+++ b/internal/claimtemplate/testdata/with-secrets.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: resources.stuttgart-things.com/v1alpha1
+kind: ClaimTemplate
+metadata:
+  name: app-with-secrets
+  title: App Deployment with Secrets
+  description: Deploys an app via Flux Kustomization with an encrypted secret
+  tags:
+    - flux
+    - app
+spec:
+  type: app
+  source: oci://ghcr.io/stuttgart-things/claim-flux-kustomizations
+  parameters:
+    - name: appName
+      title: Application Name
+      type: string
+      default: my-app
+      required: true
+    - name: namespace
+      title: Namespace
+      type: string
+      default: default
+      required: true
+  secrets:
+    - name: "{{.secretName}}"
+      namespace: "{{.secretNamespace}}"
+      parameters:
+        - name: API_TOKEN
+          title: API Token
+          type: string
+          required: true
+        - name: DB_PASSWORD
+          title: Database Password
+          type: string
+          required: true


### PR DESCRIPTION
## Summary
- Add `SecretTemplate` struct with `Name`, `Namespace`, and `Parameters` fields
- Add `Secrets []SecretTemplate` to `ClaimTemplateSpec` (optional, backwards compatible)
- Add testdata template `with-secrets.yaml` and corresponding unit tests
- All existing templates without `secrets` continue to work unchanged

## Test plan
- [x] New `TestLoadClaimTemplate_WithSecrets` — validates secrets parsing
- [x] New `TestLoadClaimTemplate_WithoutSecrets` — confirms backwards compatibility
- [x] All existing tests pass (`go test ./...`)

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)