### PR TITLE
feat: add function calls in profile for dynamic parameter resolution

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stuttgart-things/claim-machinery-api/internal/api"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/functions"
 	"github.com/stuttgart-things/claim-machinery-api/internal/notify"
 )
 
@@ -86,7 +87,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 	if profilePath == "" {
 		server, err = api.NewServerWithTemplates(dirTemplates)
 	} else {
-		profileTemplates, sources, err2 := app.LoadTemplatesFromProfile(profilePath)
+		profileResult, err2 := app.LoadProfileWithFunctions(profilePath)
 		if err2 != nil {
 			log.Fatalf("failed to load templates from profile: %v", err2)
 		}
@@ -96,7 +97,7 @@ func runServer(cmd *cobra.Command, args []string) error {
 		for _, t := range dirTemplates {
 			merged[t.Metadata.Name] = t
 		}
-		for _, t := range profileTemplates {
+		for _, t := range profileResult.Templates {
 			merged[t.Metadata.Name] = t
 		}
 		final := make([]*claimtemplate.ClaimTemplate, 0, len(merged))
@@ -104,8 +105,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 			final = append(final, t)
 		}
 
-		fmt.Printf("🧾 Loaded %d templates from profile %s\n", len(profileTemplates), profilePath)
-		for _, s := range sources {
+		fmt.Printf("🧾 Loaded %d templates from profile %s\n", len(profileResult.Templates), profilePath)
+		for _, s := range profileResult.Sources {
 			fmt.Printf("   • source: %s\n", s)
 		}
 		fmt.Printf("🧾 Templates in use (%d):\n", len(final))
@@ -114,6 +115,9 @@ func runServer(cmd *cobra.Command, args []string) error {
 		}
 
 		server, err = api.NewServerWithTemplates(final)
+		if err == nil {
+			server.SetFunctions(profileResult.Functions)
+		}
 	}
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
@@ -213,40 +217,40 @@ func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePa
 			lastHash = currentHash
 			log.Printf("Profile changed, reloading templates... (source: %s)", profilePath)
 
-			templates, err := loadMergedTemplates(enableTemplatesDir, templatesDir, profilePath)
+			templates, reg, err := loadMergedTemplates(enableTemplatesDir, templatesDir, profilePath)
 			if err != nil {
 				log.Printf("Failed to reload templates: %v (keeping previous)", err)
 				continue
 			}
 
-			server.UpdateTemplates(templates)
+			server.UpdateTemplatesAndFunctions(templates, reg)
 			log.Printf("Templates reloaded successfully (%d templates)", len(templates))
 		}
 	}
 }
 
 // loadMergedTemplates loads and merges templates from directory and profile,
-// replicating the startup merge logic.
-func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath string) ([]*claimtemplate.ClaimTemplate, error) {
+// replicating the startup merge logic. Also returns the function registry.
+func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath string) ([]*claimtemplate.ClaimTemplate, *functions.Registry, error) {
 	var dirTemplates []*claimtemplate.ClaimTemplate
 	if enableTemplatesDir {
 		var err error
 		dirTemplates, err = app.LoadAllTemplates(templatesDir)
 		if err != nil {
-			return nil, fmt.Errorf("load templates from dir: %w", err)
+			return nil, nil, fmt.Errorf("load templates from dir: %w", err)
 		}
 	}
 
-	profileTemplates, _, err := app.LoadTemplatesFromProfile(profilePath)
+	profileResult, err := app.LoadProfileWithFunctions(profilePath)
 	if err != nil {
-		return nil, fmt.Errorf("load templates from profile: %w", err)
+		return nil, nil, fmt.Errorf("load templates from profile: %w", err)
 	}
 
 	merged := make(map[string]*claimtemplate.ClaimTemplate)
 	for _, t := range dirTemplates {
 		merged[t.Metadata.Name] = t
 	}
-	for _, t := range profileTemplates {
+	for _, t := range profileResult.Templates {
 		merged[t.Metadata.Name] = t
 	}
 
@@ -254,7 +258,7 @@ func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath stri
 	for _, t := range merged {
 		result = append(result, t)
 	}
-	return result, nil
+	return result, profileResult.Functions, nil
 }
 
 // profileHash returns the SHA-256 hex digest of a profile source (local file or remote URL).

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -105,8 +105,8 @@ func (s *Server) orderClaim(w http.ResponseWriter, r *http.Request) {
 	// Debug: log received parameters
 	debugParams("Received from request", req.Parameters)
 
-	// Build parameter values (merge request params with defaults)
-	params := app.BuildParameterValues(tmpl)
+	// Build parameter values (merge request params with defaults + function calls)
+	params := app.BuildParameterValuesWithFunctions(tmpl, s.GetFunctions())
 	for key, value := range req.Parameters {
 		params[key] = value
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/functions"
 	"github.com/stuttgart-things/claim-machinery-api/internal/notify"
 	"github.com/stuttgart-things/claim-machinery-api/internal/version"
 )
@@ -23,6 +24,7 @@ type Server struct {
 	http      *http.Server
 	mu        sync.RWMutex
 	templates map[string]*claimtemplate.ClaimTemplate
+	functions *functions.Registry
 	homerun   notify.HomerunConfig
 }
 
@@ -152,6 +154,21 @@ func (s *Server) SetHomerunConfig(cfg notify.HomerunConfig) {
 	s.homerun = cfg
 }
 
+// SetFunctions sets the function registry for dynamic parameter resolution.
+func (s *Server) SetFunctions(reg *functions.Registry) {
+	s.mu.Lock()
+	s.functions = reg
+	s.mu.Unlock()
+}
+
+// GetFunctions returns the current function registry.
+func (s *Server) GetFunctions() *functions.Registry {
+	s.mu.RLock()
+	r := s.functions
+	s.mu.RUnlock()
+	return r
+}
+
 // UpdateTemplates replaces the in-memory template map with the given templates.
 func (s *Server) UpdateTemplates(templates []*claimtemplate.ClaimTemplate) {
 	m := make(map[string]*claimtemplate.ClaimTemplate, len(templates))
@@ -160,6 +177,18 @@ func (s *Server) UpdateTemplates(templates []*claimtemplate.ClaimTemplate) {
 	}
 	s.mu.Lock()
 	s.templates = m
+	s.mu.Unlock()
+}
+
+// UpdateTemplatesAndFunctions replaces both templates and functions atomically.
+func (s *Server) UpdateTemplatesAndFunctions(templates []*claimtemplate.ClaimTemplate, reg *functions.Registry) {
+	m := make(map[string]*claimtemplate.ClaimTemplate, len(templates))
+	for i, t := range templates {
+		m[t.Metadata.Name] = templates[i]
+	}
+	s.mu.Lock()
+	s.templates = m
+	s.functions = reg
 	s.mu.Unlock()
 }
 

--- a/internal/app/profile.go
+++ b/internal/app/profile.go
@@ -11,37 +11,73 @@ import (
 	"time"
 
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/functions"
 	"gopkg.in/yaml.v3"
 )
 
 // profileYAML represents the structure of the profile file.
 // Support both "templates" and the common misspelling "tenplates".
 type profileYAML struct {
-	Templates []string `yaml:"templates"`
-	Tenplates []string `yaml:"tenplates"`
+	Templates []string               `yaml:"templates"`
+	Tenplates []string               `yaml:"tenplates"`
+	Functions []functions.FunctionDef `yaml:"functions,omitempty"`
+}
+
+// ProfileResult holds everything loaded from a profile file.
+type ProfileResult struct {
+	Templates []*claimtemplate.ClaimTemplate
+	Sources   []string
+	Functions *functions.Registry
+}
+
+// LoadProfileWithFunctions loads templates and functions from a profile file.
+func LoadProfileWithFunctions(profilePath string) (*ProfileResult, error) {
+	p, err := parseProfile(profilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	templates, sources := loadTemplateEntries(p)
+
+	return &ProfileResult{
+		Templates: templates,
+		Sources:   sources,
+		Functions: functions.NewRegistry(p.Functions),
+	}, nil
 }
 
 // LoadTemplatesFromProfile loads claim templates from a YAML profile file.
 // profilePath can be a local file path or an HTTP/HTTPS URL. Individual
 // entries inside the profile can also be local paths or URLs.
 func LoadTemplatesFromProfile(profilePath string) ([]*claimtemplate.ClaimTemplate, []string, error) {
+	p, err := parseProfile(profilePath)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	templates, sources := loadTemplateEntries(p)
+	return templates, sources, nil
+}
+
+// parseProfile reads and parses a profile YAML from a local path or URL.
+func parseProfile(profilePath string) (*profileYAML, error) {
 	var reader io.ReadCloser
 
 	if strings.HasPrefix(profilePath, "http://") || strings.HasPrefix(profilePath, "https://") {
 		tmpPath, err := downloadToTemp(profilePath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("download profile from %s: %w", profilePath, err)
+			return nil, fmt.Errorf("download profile from %s: %w", profilePath, err)
 		}
 		defer os.Remove(tmpPath)
 		f, err := os.Open(tmpPath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("open downloaded profile: %w", err)
+			return nil, fmt.Errorf("open downloaded profile: %w", err)
 		}
 		reader = f
 	} else {
 		f, err := os.Open(profilePath)
 		if err != nil {
-			return nil, nil, fmt.Errorf("open profile: %w", err)
+			return nil, fmt.Errorf("open profile: %w", err)
 		}
 		reader = f
 	}
@@ -49,9 +85,13 @@ func LoadTemplatesFromProfile(profilePath string) ([]*claimtemplate.ClaimTemplat
 
 	var p profileYAML
 	if err := yaml.NewDecoder(reader).Decode(&p); err != nil {
-		return nil, nil, fmt.Errorf("parse profile yaml: %w", err)
+		return nil, fmt.Errorf("parse profile yaml: %w", err)
 	}
+	return &p, nil
+}
 
+// loadTemplateEntries resolves template entries (local or remote) from a parsed profile.
+func loadTemplateEntries(p *profileYAML) ([]*claimtemplate.ClaimTemplate, []string) {
 	entries := append([]string{}, p.Templates...)
 	if len(p.Tenplates) > 0 {
 		entries = append(entries, p.Tenplates...)
@@ -98,7 +138,7 @@ func LoadTemplatesFromProfile(profilePath string) ([]*claimtemplate.ClaimTemplat
 		sources = append(sources, e)
 	}
 
-	return out, sources, nil
+	return out, sources
 }
 
 func validateURL(u string) error {

--- a/internal/app/profile_test.go
+++ b/internal/app/profile_test.go
@@ -80,3 +80,21 @@ func TestLoadTemplatesFromProfile_MissingFile(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "open profile")
 }
+
+func TestLoadProfileWithFunctions_ParsesFunctions(t *testing.T) {
+	result, err := LoadProfileWithFunctions("testdata/profile-with-functions.yaml")
+	require.NoError(t, err)
+	require.Len(t, result.Templates, 1)
+	require.Equal(t, "test-simple", result.Templates[0].Metadata.Name)
+	require.NotNil(t, result.Functions)
+	require.True(t, result.Functions.Has("get-ip"))
+	require.False(t, result.Functions.Has("nonexistent"))
+}
+
+func TestLoadProfileWithFunctions_NoFunctions(t *testing.T) {
+	result, err := LoadProfileWithFunctions("testdata/profile.yaml")
+	require.NoError(t, err)
+	require.Len(t, result.Templates, 1)
+	require.NotNil(t, result.Functions)
+	require.False(t, result.Functions.Has("get-ip"))
+}

--- a/internal/app/renderer.go
+++ b/internal/app/renderer.go
@@ -5,15 +5,36 @@ import (
 	"log"
 
 	"github.com/stuttgart-things/claim-machinery-api/internal/claimtemplate"
+	"github.com/stuttgart-things/claim-machinery-api/internal/functions"
 	"github.com/stuttgart-things/claim-machinery-api/internal/render"
 )
 
-// BuildParameterValues creates a map of parameter values from a template
-// Uses default values where available
+// BuildParameterValues creates a map of parameter values from a template.
+// Uses default values where available.
 func BuildParameterValues(t *claimtemplate.ClaimTemplate) map[string]interface{} {
+	return BuildParameterValuesWithFunctions(t, nil)
+}
+
+// BuildParameterValuesWithFunctions creates a map of parameter values from a template.
+// Parameters with a valueFrom spec are resolved via the function registry.
+func BuildParameterValuesWithFunctions(t *claimtemplate.ClaimTemplate, reg *functions.Registry) map[string]interface{} {
 	params := make(map[string]interface{})
 
 	for _, p := range t.Spec.Parameters {
+		// Try resolving via valueFrom function first
+		if p.ValueFrom != nil && reg != nil {
+			val, err := reg.Resolve(&functions.ValueFromSpec{
+				Function: p.ValueFrom.Function,
+				Args:     p.ValueFrom.Args,
+			})
+			if err != nil {
+				log.Printf("⚠️  failed to resolve valueFrom for parameter %q (function %q): %v", p.Name, p.ValueFrom.Function, err)
+			} else {
+				params[p.Name] = val
+				continue
+			}
+		}
+
 		// Use default value if available, otherwise use a reasonable default
 		if p.Default != nil {
 			// For multiselect parameters, convert []interface{} defaults to []string
@@ -52,10 +73,15 @@ func BuildParameterValues(t *claimtemplate.ClaimTemplate) map[string]interface{}
 
 // RenderTemplate renders a claim template using KCL with optional custom parameters
 func RenderTemplate(t *claimtemplate.ClaimTemplate, customParams ...map[string]interface{}) (string, error) {
-	// Build parameter values from template defaults
-	params := BuildParameterValues(t)
+	return RenderTemplateWithFunctions(t, nil, customParams...)
+}
 
-	// Merge custom parameters if provided
+// RenderTemplateWithFunctions renders a claim template, resolving valueFrom parameters via the registry.
+func RenderTemplateWithFunctions(t *claimtemplate.ClaimTemplate, reg *functions.Registry, customParams ...map[string]interface{}) (string, error) {
+	// Build parameter values from template defaults + function calls
+	params := BuildParameterValuesWithFunctions(t, reg)
+
+	// Merge custom parameters if provided (user overrides take precedence)
 	if len(customParams) > 0 && customParams[0] != nil {
 		for key, value := range customParams[0] {
 			params[key] = value

--- a/internal/app/testdata/profile-with-functions.yaml
+++ b/internal/app/testdata/profile-with-functions.yaml
@@ -1,0 +1,10 @@
+functions:
+  - name: get-ip
+    type: http
+    method: GET
+    url: "${API_URL}/api/v1/networks/${networkKey}/available"
+    response:
+      extract: "ip"
+
+templates:
+  - testdata/simple-template.yaml

--- a/internal/claimtemplate/claimtemplate.go
+++ b/internal/claimtemplate/claimtemplate.go
@@ -38,6 +38,12 @@ type SecretTemplate struct {
 	Parameters []Parameter `yaml:"parameters" json:"parameters"` // secret key definitions
 }
 
+// ValueFromSpec references a profile function to dynamically resolve a parameter value.
+type ValueFromSpec struct {
+	Function string            `yaml:"function" json:"function"`
+	Args     map[string]string `yaml:"args" json:"args"`
+}
+
 type Parameter struct {
 	Name        string      `yaml:"name" json:"name"`
 	Title       string      `yaml:"title" json:"title"`
@@ -58,6 +64,10 @@ type Parameter struct {
 	// Multiselect allows selecting multiple values from enum options
 	// Only applies to parameters with enum values
 	Multiselect bool `yaml:"multiselect,omitempty" json:"multiselect,omitempty"`
+
+	// ValueFrom resolves this parameter's value by calling a function defined in the profile.
+	// The resolved value is used as the default; users can still override it interactively.
+	ValueFrom *ValueFromSpec `yaml:"valueFrom,omitempty" json:"valueFrom,omitempty"`
 
 	// Validation
 	Pattern   string `yaml:"pattern,omitempty" json:"pattern,omitempty"`

--- a/internal/functions/functions.go
+++ b/internal/functions/functions.go
@@ -1,0 +1,226 @@
+package functions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// FunctionDef defines a reusable function that can be called to resolve parameter values.
+type FunctionDef struct {
+	Name     string            `yaml:"name" json:"name"`
+	Type     string            `yaml:"type" json:"type"`       // "http"
+	Method   string            `yaml:"method" json:"method"`   // GET, POST
+	URL      string            `yaml:"url" json:"url"`         // supports ${var} placeholders
+	Headers  map[string]string `yaml:"headers,omitempty" json:"headers,omitempty"`
+	Body     map[string]any    `yaml:"body,omitempty" json:"body,omitempty"`
+	Response ResponseExtract   `yaml:"response" json:"response"`
+}
+
+// ResponseExtract defines how to extract a value from the function response.
+type ResponseExtract struct {
+	// Extract is a dot-separated path into the JSON response (e.g. "ip", "data.address").
+	Extract string `yaml:"extract" json:"extract"`
+}
+
+// ValueFromSpec references a function and provides arguments for parameter resolution.
+type ValueFromSpec struct {
+	Function string            `yaml:"function" json:"function"`
+	Args     map[string]string `yaml:"args" json:"args"`
+}
+
+// Registry holds loaded function definitions for lookup.
+type Registry struct {
+	funcs map[string]*FunctionDef
+}
+
+// NewRegistry creates a Registry from a slice of FunctionDef.
+func NewRegistry(defs []FunctionDef) *Registry {
+	m := make(map[string]*FunctionDef, len(defs))
+	for i := range defs {
+		m[defs[i].Name] = &defs[i]
+	}
+	return &Registry{funcs: m}
+}
+
+// Resolve calls the function referenced by spec and returns the extracted value.
+func (r *Registry) Resolve(spec *ValueFromSpec) (string, error) {
+	if r == nil || spec == nil {
+		return "", fmt.Errorf("nil registry or spec")
+	}
+
+	fn, ok := r.funcs[spec.Function]
+	if !ok {
+		return "", fmt.Errorf("function %q not found in registry", spec.Function)
+	}
+
+	switch fn.Type {
+	case "http":
+		return executeHTTP(fn, spec.Args)
+	default:
+		return "", fmt.Errorf("unsupported function type %q", fn.Type)
+	}
+}
+
+// Has returns true if the registry contains the named function.
+func (r *Registry) Has(name string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.funcs[name]
+	return ok
+}
+
+func executeHTTP(fn *FunctionDef, args map[string]string) (string, error) {
+	url := substituteVars(fn.URL, args)
+	method := strings.ToUpper(fn.Method)
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	var bodyReader io.Reader
+	if fn.Body != nil && method == http.MethodPost {
+		resolved := substituteBodyVars(fn.Body, args)
+		data, err := json.Marshal(resolved)
+		if err != nil {
+			return "", fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	// Set default Content-Type for POST
+	if method == http.MethodPost && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Apply configured headers
+	for k, v := range fn.Headers {
+		req.Header.Set(k, substituteVars(v, args))
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("execute function %q: %w", fn.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("function %q returned status %d: %s", fn.Name, resp.StatusCode, string(body))
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response body: %w", err)
+	}
+
+	return extractValue(body, fn.Response.Extract)
+}
+
+// substituteVars replaces ${key} placeholders in s with values from args,
+// falling back to environment variables.
+func substituteVars(s string, args map[string]string) string {
+	result := s
+	for k, v := range args {
+		result = strings.ReplaceAll(result, "${"+k+"}", v)
+	}
+	// Resolve remaining ${ENV_VAR} from environment
+	for {
+		start := strings.Index(result, "${")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(result[start:], "}")
+		if end == -1 {
+			break
+		}
+		varName := result[start+2 : start+end]
+		envVal := os.Getenv(varName)
+		result = result[:start] + envVal + result[start+end+1:]
+	}
+	return result
+}
+
+// substituteBodyVars recursively substitutes ${key} in body map values.
+func substituteBodyVars(body map[string]any, args map[string]string) map[string]any {
+	out := make(map[string]any, len(body))
+	for k, v := range body {
+		switch val := v.(type) {
+		case string:
+			resolved := substituteVars(val, args)
+			// Convert pure boolean/numeric strings to native types
+			if resolved == "true" {
+				out[k] = true
+			} else if resolved == "false" {
+				out[k] = false
+			} else {
+				out[k] = resolved
+			}
+		case map[string]any:
+			out[k] = substituteBodyVars(val, args)
+		default:
+			// Check if it's a ${var} placeholder stored as non-string (e.g. boolean template)
+			s := fmt.Sprintf("%v", val)
+			if strings.Contains(s, "${") {
+				resolved := substituteVars(s, args)
+				// Try to preserve original type
+				if resolved == "true" {
+					out[k] = true
+				} else if resolved == "false" {
+					out[k] = false
+				} else {
+					out[k] = resolved
+				}
+			} else {
+				out[k] = v
+			}
+		}
+	}
+	return out
+}
+
+// extractValue extracts a value from JSON using a dot-separated path.
+func extractValue(data []byte, path string) (string, error) {
+	if path == "" {
+		s := strings.TrimSpace(string(data))
+		// Strip surrounding quotes from raw JSON string values
+		if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+			s = s[1 : len(s)-1]
+		}
+		return s, nil
+	}
+
+	var obj any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return "", fmt.Errorf("parse response JSON: %w", err)
+	}
+
+	parts := strings.Split(path, ".")
+	current := obj
+
+	for _, part := range parts {
+		switch v := current.(type) {
+		case map[string]any:
+			val, ok := v[part]
+			if !ok {
+				return "", fmt.Errorf("key %q not found in response at path %q", part, path)
+			}
+			current = val
+		default:
+			return "", fmt.Errorf("cannot traverse into %T at key %q", current, part)
+		}
+	}
+
+	return fmt.Sprintf("%v", current), nil
+}

--- a/internal/functions/functions_test.go
+++ b/internal/functions/functions_test.go
@@ -1,0 +1,176 @@
+package functions
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubstituteVars(t *testing.T) {
+	args := map[string]string{
+		"networkKey": "10.31.103",
+		"cluster":    "infra",
+	}
+
+	result := substituteVars("http://clusterbook:8080/api/v1/networks/${networkKey}/assign", args)
+	require.Equal(t, "http://clusterbook:8080/api/v1/networks/10.31.103/assign", result)
+}
+
+func TestSubstituteVars_EnvFallback(t *testing.T) {
+	t.Setenv("CLUSTERBOOK_URL", "http://localhost:9090")
+	args := map[string]string{"networkKey": "10.31.103"}
+
+	result := substituteVars("${CLUSTERBOOK_URL}/api/v1/networks/${networkKey}/ips", args)
+	require.Equal(t, "http://localhost:9090/api/v1/networks/10.31.103/ips", result)
+}
+
+func TestSubstituteBodyVars(t *testing.T) {
+	body := map[string]any{
+		"cluster":    "${cluster}",
+		"status":     "${status}",
+		"create_dns": "${createDns}",
+	}
+	args := map[string]string{
+		"cluster":   "my-cluster",
+		"status":    "ASSIGNED",
+		"createDns": "true",
+	}
+
+	result := substituteBodyVars(body, args)
+	require.Equal(t, "my-cluster", result["cluster"])
+	require.Equal(t, "ASSIGNED", result["status"])
+	require.Equal(t, true, result["create_dns"])
+}
+
+func TestExtractValue_Simple(t *testing.T) {
+	data := []byte(`{"ip":"10.31.103.6","status":"ASSIGNED"}`)
+	val, err := extractValue(data, "ip")
+	require.NoError(t, err)
+	require.Equal(t, "10.31.103.6", val)
+}
+
+func TestExtractValue_Nested(t *testing.T) {
+	data := []byte(`{"data":{"address":"10.31.103.6"}}`)
+	val, err := extractValue(data, "data.address")
+	require.NoError(t, err)
+	require.Equal(t, "10.31.103.6", val)
+}
+
+func TestExtractValue_Empty(t *testing.T) {
+	data := []byte(`"10.31.103.6"`)
+	val, err := extractValue(data, "")
+	require.NoError(t, err)
+	require.Equal(t, "10.31.103.6", val)
+}
+
+func TestExtractValue_KeyNotFound(t *testing.T) {
+	data := []byte(`{"ip":"10.31.103.6"}`)
+	_, err := extractValue(data, "address")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestRegistry_Resolve_GET(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/api/v1/networks/10.31.103/ips", r.URL.Path)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]string{
+			{"ip": "10.31.103.6", "digit": "6", "status": "", "cluster": ""},
+		})
+	}))
+	defer srv.Close()
+
+	reg := NewRegistry([]FunctionDef{
+		{
+			Name:   "get-available-ip",
+			Type:   "http",
+			Method: "GET",
+			URL:    srv.URL + "/api/v1/networks/${networkKey}/ips",
+			Response: ResponseExtract{
+				Extract: "",
+			},
+		},
+	})
+
+	val, err := reg.Resolve(&ValueFromSpec{
+		Function: "get-available-ip",
+		Args:     map[string]string{"networkKey": "10.31.103"},
+	})
+	require.NoError(t, err)
+	require.Contains(t, val, "10.31.103.6")
+}
+
+func TestRegistry_Resolve_POST(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/api/v1/networks/192.168.10/assign", r.URL.Path)
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		require.Equal(t, "infra", body["cluster"])
+		require.Equal(t, "ASSIGNED", body["status"])
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"ip":      "192.168.10.150",
+			"cluster": "infra",
+			"status":  "ASSIGNED",
+		})
+	}))
+	defer srv.Close()
+
+	reg := NewRegistry([]FunctionDef{
+		{
+			Name:   "assign-ip",
+			Type:   "http",
+			Method: "POST",
+			URL:    srv.URL + "/api/v1/networks/${networkKey}/assign",
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			Body: map[string]any{
+				"cluster":    "${cluster}",
+				"status":     "${status}",
+				"create_dns": "${createDns}",
+			},
+			Response: ResponseExtract{Extract: "ip"},
+		},
+	})
+
+	val, err := reg.Resolve(&ValueFromSpec{
+		Function: "assign-ip",
+		Args: map[string]string{
+			"networkKey": "192.168.10",
+			"cluster":    "infra",
+			"status":     "ASSIGNED",
+			"createDns":  "false",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "192.168.10.150", val)
+}
+
+func TestRegistry_Resolve_FunctionNotFound(t *testing.T) {
+	reg := NewRegistry(nil)
+	_, err := reg.Resolve(&ValueFromSpec{Function: "nonexistent"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
+}
+
+func TestRegistry_Has(t *testing.T) {
+	reg := NewRegistry([]FunctionDef{{Name: "test-fn", Type: "http"}})
+	require.True(t, reg.Has("test-fn"))
+	require.False(t, reg.Has("missing"))
+}
+
+func TestRegistry_Nil(t *testing.T) {
+	var reg *Registry
+	require.False(t, reg.Has("anything"))
+	_, err := reg.Resolve(&ValueFromSpec{Function: "test"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Adds a `functions` section to the profile YAML for defining reusable HTTP function calls
- Template parameters can reference these functions via a new `valueFrom` field
- At render time, `valueFrom` parameters are resolved by calling the configured HTTP endpoint
- Primary use case: reserving IPs from clusterbook's IPAM API when rendering cilium/flux claims
- User-provided parameters still override function-resolved values

### New types

```yaml
# profile.yaml
functions:
  - name: clusterbook-assign-ip
    type: http
    method: POST
    url: "${CLUSTERBOOK_URL}/api/v1/networks/${networkKey}/assign"
    body:
      cluster: "${cluster}"
      status: "${status}"
    response:
      extract: "ip"

# template parameter
- name: CILIUM_LB_IP_START
  valueFrom:
    function: clusterbook-assign-ip
    args:
      networkKey: "192.168.10"
      cluster: "infra"
```

### Files changed

- `internal/functions/` - New package: Registry, FunctionDef, HTTP executor with variable substitution
- `internal/claimtemplate/claimtemplate.go` - Added `ValueFrom` field to `Parameter`
- `internal/app/profile.go` - Added `LoadProfileWithFunctions()`, refactored profile parsing
- `internal/app/renderer.go` - Added `BuildParameterValuesWithFunctions()` and `RenderTemplateWithFunctions()`
- `internal/api/server.go` - Server stores and exposes function registry
- `internal/api/handlers.go` - `orderClaim` uses function-aware parameter builder
- `cmd/server.go` - Wires functions from profile through server startup and reload

Closes #85

## Test plan
- [x] `go test ./...` passes (all packages)
- [x] `go build ./...` succeeds
- [x] New unit tests for function executor (substitution, extraction, HTTP calls)
- [x] New unit tests for profile loading with functions
- [x] Existing tests unaffected (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)