### PR TITLE
fix: show profile path instead of templates dir in startup log

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -164,7 +164,12 @@ func runServer(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("✓ API server listening on http://localhost:8080")
-	fmt.Printf("📂 Using templates directory: %s\n", templatesDir)
+	if enableTemplatesDir {
+		fmt.Printf("📂 Using templates directory: %s\n", templatesDir)
+	}
+	if profilePath != "" {
+		fmt.Printf("🧾 Using template profile: %s\n", profilePath)
+	}
 	fmt.Println("\n📋 Available endpoints:")
 	fmt.Println("  GET  /health                                    - Health check")
 	fmt.Println("  GET  /api/v1/claim-templates                    - List templates")


### PR DESCRIPTION
## Summary
- Startup log now only shows "Using templates directory" when directory loading is enabled
- Shows "Using template profile" with the profile path when a profile is configured
- Fixes misleading log output when running with `TEMPLATE_PROFILE_PATH` only

## Test plan
- [ ] Run with `TEMPLATE_PROFILE_PATH` set, verify log shows profile path, not templates dir
- [ ] Run with `--templates-dir` set, verify log shows templates directory
- [ ] Run with both set, verify both are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)