### PR TITLE
fix: pre-seed user params for valueFrom arg resolution

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -105,17 +105,20 @@ func (s *Server) orderClaim(w http.ResponseWriter, r *http.Request) {
 	// Debug: log received parameters
 	debugParams("Received from request", req.Parameters)
 
-	// Build parameter values (merge request params with defaults + function calls)
-	params := app.BuildParameterValuesWithFunctions(tmpl, s.GetFunctions())
-	for key, value := range req.Parameters {
-		params[key] = value
+	// Pre-seed user-provided params so valueFrom arg references (e.g. {{.networkKey}}) resolve correctly
+	userParams := make(map[string]interface{}, len(req.Parameters))
+	for k, v := range req.Parameters {
+		userParams[k] = v
 	}
+
+	// Build parameter values (merge request params with defaults + function calls)
+	params := app.BuildParameterValuesWithFunctionsAndUserParams(tmpl, s.GetFunctions(), userParams)
 
 	// Debug: log merged parameters
 	debugParams("After merge", params)
 
-	// Render template with custom parameters
-	rendered, err := app.RenderTemplate(tmpl, params)
+	// Render template directly with pre-built params (skip BuildParameterValues rebuild)
+	rendered, err := app.RenderTemplateFromParams(tmpl, params)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]string{

--- a/internal/app/renderer.go
+++ b/internal/app/renderer.go
@@ -19,7 +19,18 @@ func BuildParameterValues(t *claimtemplate.ClaimTemplate) map[string]interface{}
 // BuildParameterValuesWithFunctions creates a map of parameter values from a template.
 // Parameters with a valueFrom spec are resolved via the function registry.
 func BuildParameterValuesWithFunctions(t *claimtemplate.ClaimTemplate, reg *functions.Registry) map[string]interface{} {
+	return BuildParameterValuesWithFunctionsAndUserParams(t, reg, nil)
+}
+
+// BuildParameterValuesWithFunctionsAndUserParams creates a map of parameter values from a template.
+// User-provided params are pre-seeded so that valueFrom arg references (e.g. {{.networkKey}}) resolve correctly.
+func BuildParameterValuesWithFunctionsAndUserParams(t *claimtemplate.ClaimTemplate, reg *functions.Registry, userParams map[string]interface{}) map[string]interface{} {
 	params := make(map[string]interface{})
+
+	// Pre-seed with user-provided values so valueFrom references can resolve them
+	for k, v := range userParams {
+		params[k] = v
+	}
 
 	for _, p := range t.Spec.Parameters {
 		// Try resolving via valueFrom function first
@@ -55,6 +66,11 @@ func BuildParameterValuesWithFunctions(t *claimtemplate.ClaimTemplate, reg *func
 			}
 		}
 	fallback:
+
+		// Skip if user already provided a value for this parameter
+		if _, hasUser := userParams[p.Name]; hasUser {
+			continue
+		}
 
 		// Use default value if available, otherwise use a reasonable default
 		if p.Default != nil {
@@ -110,6 +126,21 @@ func RenderTemplateWithFunctions(t *claimtemplate.ClaimTemplate, reg *functions.
 	}
 
 	// Render using KCL from OCI source
+	result, err := render.RenderKCLFromOCI(t.Spec.Source, t.Spec.Tag, params)
+	if err != nil {
+		return "", fmt.Errorf("rendering failed for template %s: %w", t.Metadata.Name, err)
+	}
+
+	if result == "" {
+		return "", fmt.Errorf("rendering produced empty result for template %s", t.Metadata.Name)
+	}
+
+	return result, nil
+}
+
+// RenderTemplateFromParams renders a claim template using pre-built parameter values.
+// Unlike RenderTemplate, this does not rebuild parameters from the template definition.
+func RenderTemplateFromParams(t *claimtemplate.ClaimTemplate, params map[string]interface{}) (string, error) {
 	result, err := render.RenderKCLFromOCI(t.Spec.Source, t.Spec.Tag, params)
 	if err != nil {
 		return "", fmt.Errorf("rendering failed for template %s: %w", t.Metadata.Name, err)

--- a/internal/functions/functions.go
+++ b/internal/functions/functions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -83,6 +84,8 @@ func executeHTTP(fn *FunctionDef, args map[string]string) (string, error) {
 		method = http.MethodGet
 	}
 
+	log.Printf("function %q: %s %s", fn.Name, method, url)
+
 	var bodyReader io.Reader
 	if fn.Body != nil && method == http.MethodPost {
 		resolved := substituteBodyVars(fn.Body, args)
@@ -108,7 +111,13 @@ func executeHTTP(fn *FunctionDef, args map[string]string) (string, error) {
 		req.Header.Set(k, substituteVars(v, args))
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			// Prevent redirects from changing POST to GET (301/302 behavior)
+			return http.ErrUseLastResponse
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("execute function %q: %w", fn.Name, err)


### PR DESCRIPTION
## Summary
- **Root cause**: User-provided parameters (e.g. `networkKey`, `clusterName`) were not available when resolving `{{.paramName}}` references in `valueFrom` function args, causing empty values in function URLs (e.g. `/networks//reserve` instead of `/networks/10.31.103/reserve`)
- The fallback block in `BuildParameterValues` also overwrote pre-seeded user values with empty type defaults
- Added `RenderTemplateFromParams` to avoid a redundant parameter rebuild that discarded resolved valueFrom values
- Prevented HTTP redirect-induced POST-to-GET conversion in the function HTTP client

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Manual test: `cilium-clusterbook` template with `networkKey=10.31.103` correctly resolves `CILIUM_LB_IP_START` and `CILIUM_LB_IP_STOP` via clusterbook API
- [ ] Verify existing templates without valueFrom still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)