### PR TITLE
feat: interpolate param references in default values

### DIFF
--- a/internal/app/renderer.go
+++ b/internal/app/renderer.go
@@ -86,7 +86,7 @@ func BuildParameterValuesWithFunctionsAndUserParams(t *claimtemplate.ClaimTempla
 					params[p.Name] = p.Default
 				}
 			} else {
-				params[p.Name] = p.Default
+				params[p.Name] = resolveDefaultRefs(p.Default, params)
 			}
 		} else {
 			// Provide reasonable defaults based on type
@@ -106,6 +106,18 @@ func BuildParameterValuesWithFunctionsAndUserParams(t *claimtemplate.ClaimTempla
 	}
 
 	return params
+}
+
+// resolveDefaultRefs interpolates {{.paramName}} references in a default value string.
+func resolveDefaultRefs(defaultVal interface{}, params map[string]interface{}) interface{} {
+	s, ok := defaultVal.(string)
+	if !ok || !strings.Contains(s, "{{.") {
+		return defaultVal
+	}
+	for paramName, paramVal := range params {
+		s = strings.ReplaceAll(s, "{{."+paramName+"}}", fmt.Sprintf("%v", paramVal))
+	}
+	return s
 }
 
 // RenderTemplate renders a claim template using KCL with optional custom parameters


### PR DESCRIPTION
## Summary
- Adds `resolveDefaultRefs()` to interpolate `{{.paramName}}` references in parameter default values
- Enables computed defaults that reference other resolved parameters (e.g. valueFrom-resolved IPs)
- Use case: `cilium-clusterbook` template builds `substitute` default from `CILIUM_LB_IP_START` and `CILIUM_LB_IP_STOP` values

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [ ] Manual test: `cilium-clusterbook` template renders with `postBuild.substitute` containing resolved IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)