### PR TITLE
feat: styled startup output with env table and template details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@ Claim Machinery API is a Go REST API and interactive CLI for managing Crossplane
 
 **Run locally:**
 ```bash
-go run main.go server                                    # Start API server (default port 8080)
+go run main.go                                           # Start API server (default, port 8080)
+go run main.go server                                    # Start API server (explicit)
 go run main.go render                                    # Start interactive TUI for template rendering
 go run main.go --templates-dir internal/claimtemplate/testdata --template-profile-path tests/profile.yaml
 ```
@@ -80,6 +81,7 @@ Responses use Kubernetes-style format with `apiVersion: api.claim-machinery.io/v
 | `ENABLE_HOMERUN` | Enable homerun2 notifications (`true`/`1`/`yes`) | off |
 | `HOMERUN_URL` | Omni-pitcher base URL (e.g. `https://pitcher.example.com`) | - |
 | `HOMERUN_AUTH_TOKEN` | Bearer token for pitcher `/pitch` endpoint | - |
+| `RELOAD_INTERVAL` | Profile auto-reload interval (e.g. `2m`, `30s`, `0` to disable) | `2m` |
 
 ## Testing Conventions
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ git clone https://github.com/stuttgart-things/claim-machinery-api.git
 cd claim-machinery-api
 go mod download
 
-# Run API server
+# Run API server (default when no subcommand is given)
+go run main.go
+
+# Or explicitly
 go run main.go server
 
-# Or interactive CLI (default when no subcommand is given)
+# Interactive CLI
 go run main.go render
 ```
 
@@ -194,19 +197,19 @@ curl http://localhost:8080/version
 
 ## Usage
 
-### API Server
-
-```bash
-claim-machinery-api server
-```
-
-### Interactive CLI (Default)
+### API Server (Default)
 
 ```bash
 # Default when no subcommand is given
 claim-machinery-api
 
 # Or explicitly
+claim-machinery-api server
+```
+
+### Interactive CLI
+
+```bash
 claim-machinery-api render
 ```
 
@@ -231,6 +234,7 @@ export TEMPLATES_DIR=/path/to/templates
 export TEMPLATE_PROFILE_PATH=/path/to/profile.yaml        # local file
 export TEMPLATE_PROFILE_PATH=https://example.com/profile.yaml  # or HTTP URL
 export ENABLE_TEMPLATES_DIR=true  # enable loading from templates directory
+export RELOAD_INTERVAL=2m         # profile auto-reload interval (0 to disable)
 export PORT=9090
 export LOG_FORMAT=json   # default: text
 
@@ -374,7 +378,7 @@ Connects to the running API server - no local KCL required.
 
 ```bash
 # Start API first
-go run main.go
+go run main.go server
 
 # Then run CLI
 go build -o tests/cli-api/claim-cli-api ./tests/cli-api/

--- a/cmd/logo.go
+++ b/cmd/logo.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -60,3 +62,113 @@ func renderLogo() string {
 
 // Logo returns the rendered logo with gradient colors
 var logo = renderLogo()
+
+// --- Styled output helpers ---------------------------------------------------
+
+var (
+	sectionStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#00ffff")).
+			PaddingTop(1)
+
+	methodStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(lipgloss.Color("#ff00ff"))
+
+	pathStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#00ffff"))
+
+	dimStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#888888"))
+)
+
+func renderVersionBadge(version, commit, date string) string {
+	label := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#000000")).
+		Background(lipgloss.Color("#00ffff")).
+		Bold(true).
+		Padding(0, 1).
+		Render("VERSION")
+	value := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#ffffff")).
+		Background(lipgloss.Color("#333333")).
+		Padding(0, 1).
+		Render(version)
+
+	commitLabel := dimStyle.Render(" commit:") + " " + commit
+	dateLabel := dimStyle.Render(" built:") + " " + date
+
+	return "  " + label + value + commitLabel + dateLabel
+}
+
+func printSection(title string) {
+	fmt.Println(sectionStyle.Render("  " + title))
+}
+
+func printKV(key, value string) {
+	// Pad the key before styling so ANSI codes don't break alignment
+	padded := fmt.Sprintf("%-24s", key)
+	fmt.Printf("  │ %s %s\n", dimStyle.Render(padded), value)
+}
+
+func printEnvTable(vars []struct{ name, desc, fallback string }) {
+	// Compute column widths
+	nameW, descW := len("VARIABLE"), len("DESCRIPTION")
+	for _, v := range vars {
+		if len(v.name) > nameW {
+			nameW = len(v.name)
+		}
+		if len(v.desc) > descW {
+			descW = len(v.desc)
+		}
+	}
+
+	hdr := fmt.Sprintf("  %-*s  %-*s  %s", nameW, "VARIABLE", descW, "DESCRIPTION", "VALUE")
+	fmt.Println(dimStyle.Render(hdr))
+	fmt.Println(dimStyle.Render("  " + strings.Repeat("─", nameW) + "  " + strings.Repeat("─", descW) + "  " + strings.Repeat("─", 20)))
+
+	setStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00"))
+
+	for _, v := range vars {
+		val := os.Getenv(v.name)
+		display := dimStyle.Render(v.fallback)
+		if val != "" {
+			// Mask sensitive values
+			if strings.Contains(strings.ToUpper(v.name), "TOKEN") || strings.Contains(strings.ToUpper(v.name), "SECRET") {
+				display = setStyle.Render("****")
+			} else {
+				display = setStyle.Render(val)
+			}
+		}
+		nameCol := fmt.Sprintf("%-*s", nameW, v.name)
+		descCol := fmt.Sprintf("%-*s", descW, v.desc)
+		fmt.Printf("  %s  %s  %s\n",
+			pathStyle.Render(nameCol),
+			dimStyle.Render(descCol),
+			display,
+		)
+	}
+}
+
+func printTemplateTable(templates [][3]string) {
+	nameStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#ffffff"))
+	labelImport := dimStyle.Render("import")
+	labelOCI := dimStyle.Render("oci")
+
+	for i, t := range templates {
+		fmt.Printf("  %s\n", nameStyle.Render(t[0]))
+		fmt.Printf("    %s  %s\n", labelImport, dimStyle.Render(t[2]))
+		fmt.Printf("    %s     %s\n", labelOCI, pathStyle.Render(t[1]))
+		if i < len(templates)-1 {
+			fmt.Println()
+		}
+	}
+}
+
+func printEndpoint(method, path, desc string) {
+	fmt.Printf("  │ %s  %-42s %s\n",
+		methodStyle.Render(method),
+		pathStyle.Render(path),
+		dimStyle.Render(desc),
+	)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ var (
 	templatesDir      string
 	profilePath       string
 	enableTemplatesDir bool
+	reloadInterval     string
 )
 
 var rootCmd = &cobra.Command{
@@ -25,10 +26,10 @@ var rootCmd = &cobra.Command{
 	Long: `Claim Machinery API provides a service for rendering claim templates
 using KCL (KusionStack Configuration Language) from OCI registries.
 
-By default, it launches the interactive template renderer. Use 'server' subcommand to start the API server.`,
-	// Default behavior: run render
+By default, it starts the API server. Use 'render' subcommand for the interactive template renderer.`,
+	// Default behavior: run server
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return renderCmd.RunE(cmd, args)
+		return runServer(cmd, args)
 	},
 }
 
@@ -36,6 +37,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&templatesDir, "templates-dir", "", "Path to templates directory")
 	rootCmd.PersistentFlags().StringVar(&profilePath, "template-profile-path", "", "Path to template profile YAML")
 	rootCmd.PersistentFlags().BoolVar(&enableTemplatesDir, "enable-templates-dir", false, "Enable loading templates from templates directory")
+	rootCmd.PersistentFlags().StringVar(&reloadInterval, "reload-interval", "", "Profile auto-reload interval (e.g. 2m, 30s, 0 to disable)")
 }
 
 func Execute() {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"github.com/stuttgart-things/claim-machinery-api/internal/api"
 	"github.com/stuttgart-things/claim-machinery-api/internal/app"
@@ -35,9 +37,26 @@ func init() {
 
 func runServer(cmd *cobra.Command, args []string) error {
 	fmt.Println(logo)
-	fmt.Printf("Version:    %s\n", Version)
-	fmt.Printf("Commit:     %s\n", Commit)
-	fmt.Printf("Build Date: %s\n\n", Date)
+	fmt.Println(renderVersionBadge(Version, Commit, Date))
+
+	// --- Environment variables ---------------------------------------------------
+	printSection("🔧 Environment")
+	envVars := []struct {
+		name, desc, fallback string
+	}{
+		{"PORT", "HTTP server port", "8080"},
+		{"TEMPLATES_DIR", "Local template directory", "-"},
+		{"TEMPLATE_PROFILE_PATH", "Profile YAML path", "-"},
+		{"ENABLE_TEMPLATES_DIR", "Enable template dir loading", "false"},
+		{"RELOAD_INTERVAL", "Profile auto-reload interval", "2m"},
+		{"DEBUG", "Enable debug logging", "off"},
+		{"LOG_FORMAT", "Log format (json/text)", "text"},
+		{"ENABLE_HOMERUN", "Enable homerun notifications", "off"},
+		{"HOMERUN_URL", "Omni-pitcher base URL", "-"},
+		{"HOMERUN_AUTH_TOKEN", "Bearer token for pitcher", "-"},
+		{"ENABLE_TEST_ROUTES", "Enable test endpoints", "off"},
+	}
+	printEnvTable(envVars)
 
 	// Resolve enableTemplatesDir from flag or env var
 	if !enableTemplatesDir {
@@ -66,6 +85,27 @@ func runServer(cmd *cobra.Command, args []string) error {
 		profilePath = "tests/profile.yaml"
 	}
 
+	// --- Endpoints ---------------------------------------------------------------
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	printSection("🌐 Endpoints")
+	printEndpoint("GET ", "/health", "Health check")
+	printEndpoint("GET ", "/api/v1/claim-templates", "List templates")
+	printEndpoint("GET ", "/api/v1/claim-templates/{name}", "Get template details")
+	printEndpoint("POST", "/api/v1/claim-templates/{name}/order", "Render template")
+
+	// --- Configuration -----------------------------------------------------------
+	printSection("⚙️  Configuration")
+	if enableTemplatesDir {
+		printKV("templates-dir", templatesDir)
+	}
+	if profilePath != "" {
+		printKV("profile", profilePath)
+	}
+
+	// --- Load templates ----------------------------------------------------------
 	var dirTemplates []*claimtemplate.ClaimTemplate
 	if enableTemplatesDir {
 		var err error
@@ -73,19 +113,17 @@ func runServer(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			log.Fatalf("failed to load templates from dir: %v", err)
 		}
-		fmt.Printf("📂 Using templates directory: %s\n", templatesDir)
-		fmt.Printf("🧾 Loaded %d templates from directory\n", len(dirTemplates))
-		for _, t := range dirTemplates {
-			fmt.Printf("   • %s\n", t.Metadata.Name)
-		}
-	} else {
-		fmt.Println("📂 Templates directory loading disabled")
 	}
 
 	var server *api.Server
 	var err error
+	importSources := make(map[string]string) // template name -> import path
+
 	if profilePath == "" {
 		server, err = api.NewServerWithTemplates(dirTemplates)
+		for _, t := range dirTemplates {
+			importSources[t.Metadata.Name] = templatesDir
+		}
 	} else {
 		profileResult, err2 := app.LoadProfileWithFunctions(profilePath)
 		if err2 != nil {
@@ -96,22 +134,17 @@ func runServer(cmd *cobra.Command, args []string) error {
 		merged := make(map[string]*claimtemplate.ClaimTemplate)
 		for _, t := range dirTemplates {
 			merged[t.Metadata.Name] = t
+			importSources[t.Metadata.Name] = templatesDir
 		}
-		for _, t := range profileResult.Templates {
+		for i, t := range profileResult.Templates {
 			merged[t.Metadata.Name] = t
+			if i < len(profileResult.Sources) {
+				importSources[t.Metadata.Name] = profileResult.Sources[i]
+			}
 		}
 		final := make([]*claimtemplate.ClaimTemplate, 0, len(merged))
 		for _, t := range merged {
 			final = append(final, t)
-		}
-
-		fmt.Printf("🧾 Loaded %d templates from profile %s\n", len(profileResult.Templates), profilePath)
-		for _, s := range profileResult.Sources {
-			fmt.Printf("   • source: %s\n", s)
-		}
-		fmt.Printf("🧾 Templates in use (%d):\n", len(final))
-		for _, t := range final {
-			fmt.Printf("   • %s\n", t.Metadata.Name)
 		}
 
 		server, err = api.NewServerWithTemplates(final)
@@ -119,20 +152,43 @@ func runServer(cmd *cobra.Command, args []string) error {
 			server.SetFunctions(profileResult.Functions)
 		}
 	}
+	if err == nil {
+		server.SetImportSources(importSources)
+	}
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
 	}
 
-	// Configure homerun2 notifications
+	// --- Templates summary -------------------------------------------------------
+	tplSources := server.TemplateSources()
+	printSection(fmt.Sprintf("📦 Templates (%d loaded)", len(tplSources)))
+	printTemplateTable(tplSources)
+
+	// --- Notifications -----------------------------------------------------------
 	homerunCfg := notify.LoadHomerunConfig()
 	server.SetHomerunConfig(homerunCfg)
+	printSection("🔔 Notifications")
 	if homerunCfg.Enabled {
-		fmt.Printf("📢 Homerun notifications enabled (URL: %s)\n", homerunCfg.URL)
+		printKV("homerun", fmt.Sprintf("✅ enabled (%s)", homerunCfg.URL))
 	} else {
-		fmt.Println("📢 Homerun notifications disabled")
+		printKV("homerun", "⏸️  disabled")
 	}
 
-	// Start server with automatic restart on crash
+	// --- Auto-reload ------------------------------------------------------------
+	pollInterval := resolveReloadInterval()
+	printSection("🔄 Auto-Reload")
+	if profilePath != "" && pollInterval > 0 {
+		printKV("profile watch", fmt.Sprintf("✅ enabled (every %s)", pollInterval))
+	} else if profilePath != "" {
+		printKV("profile watch", "⏸️  disabled (interval set to 0)")
+	} else {
+		printKV("profile watch", "⏸️  disabled (no profile configured)")
+	}
+
+	// --- Start server ------------------------------------------------------------
+	fmt.Println()
+	fmt.Printf("  🚀 Server listening on :%s\n\n", port)
+
 	stopCh := make(chan struct{})
 	go func() {
 		backoff := time.Second
@@ -159,29 +215,16 @@ func runServer(cmd *cobra.Command, args []string) error {
 	}()
 
 	// Start config auto-reload watcher for profile changes
-	if profilePath != "" {
-		go watchProfileForReload(stopCh, server, profilePath, enableTemplatesDir, templatesDir)
+	if profilePath != "" && pollInterval > 0 {
+		go watchProfileForReload(stopCh, server, profilePath, enableTemplatesDir, templatesDir, pollInterval)
 	}
-
-	fmt.Println("✓ API server listening on http://localhost:8080")
-	if enableTemplatesDir {
-		fmt.Printf("📂 Using templates directory: %s\n", templatesDir)
-	}
-	if profilePath != "" {
-		fmt.Printf("🧾 Using template profile: %s\n", profilePath)
-	}
-	fmt.Println("\n📋 Available endpoints:")
-	fmt.Println("  GET  /health                                    - Health check")
-	fmt.Println("  GET  /api/v1/claim-templates                    - List templates")
-	fmt.Println("  GET  /api/v1/claim-templates/{name}             - Get template details")
-	fmt.Println("  POST /api/v1/claim-templates/{name}/order       - Render template")
 
 	// Wait for interrupt signal
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 
 	sig := <-sigChan
-	fmt.Printf("\n📮 Received signal: %v\n", sig)
+	fmt.Printf("\n[server] received signal: %v, shutting down...\n", sig)
 
 	// Signal watcher and restart loop to stop
 	close(stopCh)
@@ -191,21 +234,42 @@ func runServer(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	if err := server.Stop(ctx); err != nil {
-		log.Printf("error during shutdown: %v", err)
+		log.Printf("[server] shutdown error: %v", err)
 	}
 
-	fmt.Println("✓ Server stopped gracefully")
+	fmt.Println("[server] stopped")
 	return nil
+}
+
+// resolveReloadInterval returns the reload interval from flag, env, or default (2m).
+// Returns 0 to disable auto-reload.
+func resolveReloadInterval() time.Duration {
+	raw := reloadInterval
+	if raw == "" {
+		raw = os.Getenv("RELOAD_INTERVAL")
+	}
+	if raw == "" {
+		return 2 * time.Minute
+	}
+	if raw == "0" {
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("[auto-reload] invalid interval %q, using default 2m", raw)
+		return 2 * time.Minute
+	}
+	return d
 }
 
 // watchProfileForReload periodically checks the profile for changes and
 // reloads templates into the running server when a change is detected.
 // Supports both local file paths and remote HTTP/HTTPS URLs.
-func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePath string, enableTemplatesDir bool, templatesDir string) {
-	const pollInterval = 10 * time.Second
+func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePath string, enableTemplatesDir bool, templatesDir string, pollInterval time.Duration) {
 	isRemote := strings.HasPrefix(profilePath, "http://") || strings.HasPrefix(profilePath, "https://")
 
 	lastHash := profileHash(profilePath, isRemote)
+	previousNames := server.TemplateNames()
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -220,50 +284,99 @@ func watchProfileForReload(stopCh <-chan struct{}, server *api.Server, profilePa
 				continue
 			}
 			lastHash = currentHash
-			log.Printf("Profile changed, reloading templates... (source: %s)", profilePath)
+			log.Printf("[auto-reload] profile change detected, reloading...")
 
-			templates, reg, err := loadMergedTemplates(enableTemplatesDir, templatesDir, profilePath)
+			templates, reg, sources, err := loadMergedTemplates(enableTemplatesDir, templatesDir, profilePath)
 			if err != nil {
-				log.Printf("Failed to reload templates: %v (keeping previous)", err)
+				log.Printf("[auto-reload] reload failed: %v (keeping previous)", err)
 				continue
 			}
 
 			server.UpdateTemplatesAndFunctions(templates, reg)
-			log.Printf("Templates reloaded successfully (%d templates)", len(templates))
+			server.SetImportSources(sources)
+
+			// Build new name set for diff
+			newNames := make([]string, 0, len(templates))
+			for _, t := range templates {
+				newNames = append(newNames, t.Metadata.Name)
+			}
+			sort.Strings(newNames)
+
+			// Compute added / removed
+			oldSet := make(map[string]bool, len(previousNames))
+			for _, n := range previousNames {
+				oldSet[n] = true
+			}
+			newSet := make(map[string]bool, len(newNames))
+			for _, n := range newNames {
+				newSet[n] = true
+			}
+
+			var added, removed []string
+			for _, n := range newNames {
+				if !oldSet[n] {
+					added = append(added, n)
+				}
+			}
+			for _, n := range previousNames {
+				if !newSet[n] {
+					removed = append(removed, n)
+				}
+			}
+
+			// Styled reload summary
+			printSection(fmt.Sprintf("🔄 Auto-Reload (%d templates)", len(templates)))
+			for _, n := range added {
+				fmt.Printf("  │ %s %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("#00ff00")).Render("+"), n)
+			}
+			for _, n := range removed {
+				fmt.Printf("  │ %s %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("#ff0000")).Render("−"), n)
+			}
+			if len(added) == 0 && len(removed) == 0 {
+				fmt.Println(dimStyle.Render("  │ templates unchanged (profile content updated)"))
+			}
+			printTemplateTable(server.TemplateSources())
+
+			previousNames = newNames
 		}
 	}
 }
 
 // loadMergedTemplates loads and merges templates from directory and profile,
-// replicating the startup merge logic. Also returns the function registry.
-func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath string) ([]*claimtemplate.ClaimTemplate, *functions.Registry, error) {
+// replicating the startup merge logic. Also returns the function registry and import sources.
+func loadMergedTemplates(enableTemplatesDir bool, templatesDir, profilePath string) ([]*claimtemplate.ClaimTemplate, *functions.Registry, map[string]string, error) {
 	var dirTemplates []*claimtemplate.ClaimTemplate
 	if enableTemplatesDir {
 		var err error
 		dirTemplates, err = app.LoadAllTemplates(templatesDir)
 		if err != nil {
-			return nil, nil, fmt.Errorf("load templates from dir: %w", err)
+			return nil, nil, nil, fmt.Errorf("load templates from dir: %w", err)
 		}
 	}
 
 	profileResult, err := app.LoadProfileWithFunctions(profilePath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load templates from profile: %w", err)
+		return nil, nil, nil, fmt.Errorf("load templates from profile: %w", err)
 	}
 
 	merged := make(map[string]*claimtemplate.ClaimTemplate)
+	importSources := make(map[string]string)
 	for _, t := range dirTemplates {
 		merged[t.Metadata.Name] = t
+		importSources[t.Metadata.Name] = templatesDir
 	}
-	for _, t := range profileResult.Templates {
+	for i, t := range profileResult.Templates {
 		merged[t.Metadata.Name] = t
+		if i < len(profileResult.Sources) {
+			importSources[t.Metadata.Name] = profileResult.Sources[i]
+		}
 	}
 
 	result := make([]*claimtemplate.ClaimTemplate, 0, len(merged))
 	for _, t := range merged {
 		result = append(result, t)
 	}
-	return result, profileResult.Functions, nil
+	return result, profileResult.Functions, importSources, nil
 }
 
 // profileHash returns the SHA-256 hex digest of a profile source (local file or remote URL).

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -4,7 +4,7 @@
 
 ### 1. Start the Server
 ```bash
-go run main.go
+go run main.go  # or: go run main.go server
 ```
 
 Expected output:

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ The Claim Machinery API provides a REST interface for working with Crossplane cl
 ### Running the API
 
 ```bash
-# Start the API server
+# Start the API server (default command)
 go run main.go
 
 # API available at

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"time"
 
@@ -20,12 +21,13 @@ import (
 
 // Server represents the HTTP API server
 type Server struct {
-	router    *mux.Router
-	http      *http.Server
-	mu        sync.RWMutex
-	templates map[string]*claimtemplate.ClaimTemplate
-	functions *functions.Registry
-	homerun   notify.HomerunConfig
+	router        *mux.Router
+	http          *http.Server
+	mu            sync.RWMutex
+	templates     map[string]*claimtemplate.ClaimTemplate
+	importSources map[string]string // template name -> import path (file or URL)
+	functions     *functions.Registry
+	homerun       notify.HomerunConfig
 }
 
 // NewServer creates and initializes a new HTTP server
@@ -136,16 +138,12 @@ func (s *Server) applyMiddleware() {
 
 // Start starts the HTTP server
 func (s *Server) Start() error {
-	if IsDebugEnabled() {
-		log.Println("🐛 Debug mode enabled (DEBUG=1)")
-	}
-	log.Printf("🚀 HTTP API server starting on %s", s.http.Addr)
 	return s.http.ListenAndServe()
 }
 
 // Stop gracefully stops the HTTP server
 func (s *Server) Stop(ctx context.Context) error {
-	log.Println("⏹️  Shutting down HTTP server...")
+	log.Println("[server] graceful shutdown initiated")
 	return s.http.Shutdown(ctx)
 }
 
@@ -190,6 +188,38 @@ func (s *Server) UpdateTemplatesAndFunctions(templates []*claimtemplate.ClaimTem
 	s.templates = m
 	s.functions = reg
 	s.mu.Unlock()
+}
+
+// TemplateNames returns the sorted names of all loaded templates.
+func (s *Server) TemplateNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	names := make([]string, 0, len(s.templates))
+	for name := range s.templates {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SetImportSources records where each template was imported from (file path or URL).
+func (s *Server) SetImportSources(sources map[string]string) {
+	s.mu.Lock()
+	s.importSources = sources
+	s.mu.Unlock()
+}
+
+// TemplateSources returns sorted (name, ociSource, importPath) triples for all loaded templates.
+func (s *Server) TemplateSources() [][3]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	triples := make([][3]string, 0, len(s.templates))
+	for _, t := range s.templates {
+		importPath := s.importSources[t.Metadata.Name]
+		triples = append(triples, [3]string{t.Metadata.Name, t.Spec.Source, importPath})
+	}
+	sort.Slice(triples, func(i, j int) bool { return triples[i][0] < triples[j][0] })
+	return triples
 }
 
 // getTemplateMap returns the current template map under a read lock.


### PR DESCRIPTION
## Summary
- Redesign server startup banner with lipgloss-styled sections (env vars table, endpoints, template cards, notifications, auto-reload status)
- Show template import paths (file/URL) and OCI sources in a stacked card layout
- Add environment variables table displaying all configurable vars with current/default values (sensitive tokens masked)
- Styled auto-reload logging with add/remove diff and full template table on profile changes
- Switch default command from `render` to `server`, add `--reload-interval` flag
- Update CLAUDE.md, README, and docs accordingly

## Test plan
- [x] `go test ./...` passes
- [x] Manual verification of styled output with local and remote profile templates
- [x] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)