### PR TITLE
fix: correct goreleaser ldflags variable casing

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,9 +19,9 @@ builds:
       - -s
       - -w
       - -extldflags=-static
-      - -X github.com/stuttgart-things/claim-machinery-api/cmd.version={{.Version}}
-      - -X github.com/stuttgart-things/claim-machinery-api/cmd.commit={{.Commit}}
-      - -X github.com/stuttgart-things/claim-machinery-api/cmd.date={{.Date}}
+      - -X github.com/stuttgart-things/claim-machinery-api/cmd.Version={{.Version}}
+      - -X github.com/stuttgart-things/claim-machinery-api/cmd.Commit={{.Commit}}
+      - -X github.com/stuttgart-things/claim-machinery-api/cmd.Date={{.Date}}
     goos:
       - linux
       - darwin


### PR DESCRIPTION
## Summary
- Fix ldflags in `.goreleaser.yaml` to use correct casing (`cmd.Version`, `cmd.Commit`, `cmd.Date` instead of lowercase)
- This was causing all release binaries to show `VERSION dev | commit: none | built: unknown`

## Test plan
- [x] Verified locally with `go build -ldflags` — version badge now shows injected values
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)