### PR TITLE
fix: add concurrency group to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+
 jobs:
   release:
     if: >-


### PR DESCRIPTION
## Summary
- Add `concurrency` group to release workflow so only one release runs at a time
- When both `workflow_run` and `workflow_dispatch` trigger simultaneously, the earlier run gets cancelled instead of both racing and one failing

## Test plan
- [x] Verify workflow YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)